### PR TITLE
Support integer data from BIOS

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,17 +1,23 @@
 ## Development
-* `dcspy.py` is responsible for initialise parser, G13 handler, as well as running connection with DCS.
-* `logitech.py` is responsible for initialise aircraft specific file and handling G13 display and buttons
-* `aircrafts.py` are define all supported aircrafts with details how to handle and display data from DCS, draws bitmap that will be passed to G13 handler and returns input data for buttons under G13 display
+* `dcspy.py` main script - responsible for initialise DCS-BIOS parser, Logitech G13 handler, as well as running connection to DCS.
+* `logitech.py` handling Logitech G13 display and buttons, auto-loading current aircraft
+* `aircrafts.py` are define all supported aircrafts with details how and what and display from DCS, draws bitmap that will be passed to G13 handler and returns input data for buttons under G13 display
+* `dcsbios.py` BIOS protocol parser and two buffers to fetching integer and string values `IntegerBuffer` and `StringBuffer` respectively.
 
-If you want to modify or write something by yourself, here's a quick walkthrough:
+If you want to modify or write something by yourself, here's a quick walk-through:
 * Each plan has special dict:
 ```python
-BIOS_VALUE = TypedDict('BIOS_VALUE', {'addr': int, 'len': int, 'val': str})
+BIOS_VALUE = TypedDict('BIOS_VALUE', {'class': str, 'args': Dict[str, int], 'value': Union[int, str]})
+
 self.bios_data: Dict[str, BIOS_VALUE] = {
-    'ScratchpadStr1': {'addr': 0x744e, 'len': 2, 'val': ''},
-    'FuelTotal': {'addr': 0x748a, 'len': 6, 'val': ''}}
+    'PVI_LINE2_TEXT': {'class': 'StringBuffer',
+                       'args': {'address': 0x192a, 'length': 6},
+                       'value': str()},
+    'AP_ALT_HOLD_LED': {'class': 'IntegerBuffer', 
+                        'args': {'address': 0x1936, 'mask': 0x8000, 'shift_by': 0xf}, 
+                        'value': int()}}
 ```
-which describe data to be fetch from DCS-BIOS. For required address and data length, look up in `C:\Users\xxx\Saved Games\DCS.openbeta\Scripts\DCS-BIOS\doc\control-reference.html`
+which describe data to be fetch from DCS-BIOS with buffer class and its parameters. For required address and data length, look up in `C:\Users\xxx\Saved Games\DCS.openbeta\Scripts\DCS-BIOS\doc\control-reference.html`
 * Then after detecting current plane in DCS, G13 will load instance of aircraft as `plane`
 ```python
 self.plane: Aircraft = getattr(import_module('dcspy.aircrafts'), self.plane_name)(self.g13_lcd.width, self.g13_lcd.height)
@@ -19,7 +25,8 @@ self.plane: Aircraft = getattr(import_module('dcspy.aircrafts'), self.plane_name
 * and "subscribe" for changes with callback for all fields defined in `plane` instance
 ```python
 for field_name, proto_data in self.plane.bios_data.items():
-    StringBuffer(self.parser, proto_data['addr'], proto_data['len'], partial(self.plane.set_bios, field_name))
+    buffer = getattr(import_module('dcspy.dcsbios'), proto_data['class'])
+    buffer(parser=self.parser, callback=partial(self.plane.set_bios, field_name), **proto_data['args'])
 ```
 * when, receive byte, parser will process data:
 ```python
@@ -38,6 +45,6 @@ action = {1: 'UFC_COMM1_CHANNEL_SELECT DEC',
           2: 'UFC_COMM1_CHANNEL_SELECT INC',
           3: 'UFC_COMM2_CHANNEL_SELECT DEC',
           4: 'UFC_COMM2_CHANNEL_SELECT INC'}
-return f'{action[button]}\n'
+return super().button_request(button, action.get(button, '\n'))
 ```
 Again, look it up in `control-reference.html`, in example above, COMM1 and COMM2 knobs of F/A-18C will rotate left and right.

--- a/dcspy/aircrafts.py
+++ b/dcspy/aircrafts.py
@@ -17,7 +17,7 @@ class Aircraft:
         """
         self.width = width
         self.height = height
-        self.bios_data: Dict[str, Dict['str': Union[str, int]]] = {}
+        self.bios_data: Dict[str, Dict[str: Union[str, int]]] = {}
 
     def button_request(self, button: int) -> str:
         """
@@ -82,7 +82,7 @@ class FA18Chornet(Aircraft):
         :param height: LCD height
         """
         super().__init__(width, height)
-        self.bios_data: Dict[str, Dict['str': Union[str, int]]] = {
+        self.bios_data: Dict[str, Dict[str: Union[str, int]]] = {
             'ScratchpadStr1': {'address': 0x744e, 'length': 2, 'value': str()},
             'ScratchpadStr2': {'address': 0x7450, 'length': 2, 'value': str()},
             'ScratchpadNum': {'address': 0x7446, 'length': 8, 'value': str()},
@@ -177,7 +177,7 @@ class F16C50(Aircraft):
         :param height: LCD height
         """
         super().__init__(width, height)
-        self.bios_data: Dict[str, Dict['str': Union[str, int]]] = {
+        self.bios_data: Dict[str, Dict[str: Union[str, int]]] = {
             'DEDLine1': {'address': 0x44fc, 'length': 50, 'value': str()},
             'DEDLine2': {'address': 0x452e, 'length': 50, 'value': str()},
             'DEDLine3': {'address': 0x4560, 'length': 50, 'value': str()},
@@ -208,7 +208,7 @@ class Ka50(Aircraft):
         :param height: LCD height
         """
         super().__init__(width, height)
-        self.bios_data: Dict[str, Dict['str': Union[str, int]]] = {
+        self.bios_data: Dict[str, Dict[str: Union[str, int]]] = {
             'l1_apostr1': {'address': 0x1934, 'length': 1, 'value': str()},
             'l1_apostr2': {'address': 0x1936, 'length': 1, 'value': str()},
             'l1_point': {'address': 0x1930, 'length': 1, 'value': str()},

--- a/dcspy/aircrafts.py
+++ b/dcspy/aircrafts.py
@@ -6,16 +6,6 @@ from PIL import Image, ImageDraw
 from dcspy import FONT_11, FONT_16
 from dcspy.sdk import lcd_sdk
 
-try:
-    from typing_extensions import TypedDict
-except ImportError:
-    from typing import TypedDict
-
-
-INT_BIOS = TypedDict('INT_BIOS', {'addr': int, 'mask': int, 'shift_by': int})
-STR_BIOS = TypedDict('STR_BIOS', {'addr': int, 'len': int, 'val': str})
-BIOS_VALUE = TypedDict('BIOS_VALUE', {'type': str, 'data': Union[INT_BIOS, STR_BIOS]})
-
 
 class Aircraft:
     def __init__(self, width: int, height: int) -> None:

--- a/dcspy/aircrafts.py
+++ b/dcspy/aircrafts.py
@@ -1,4 +1,4 @@
-from logging import debug, warning
+from logging import debug
 from typing import Dict, Union
 
 from PIL import Image, ImageDraw
@@ -29,19 +29,22 @@ class Aircraft:
         self.height = height
         self.bios_data: Dict[str, BIOS_VALUE] = {}
 
-    def button_request(self, button: int) -> str:
+    def button_request(self, button: int, request: str = '\n') -> str:
         """
-        Prepare specific DCS-BIOS request for button pressed.
+        Prepare aircraft specific DCS-BIOS request for button pressed.
 
         If button is out of scope new line is return.
 
         :param button: possible values 1-4
         :type: int
+        :param request: valid DCS-BIOS command as string
+        :type request: str
         :return: ready to send DCS-BIOS request
         :rtype: str
         """
         debug(f'{self.__class__.__name__} Button: {button}')
-        return '\n'
+        debug(f'Request: {request.strip()}')
+        return request
 
     @staticmethod
     def update_display(image: Image.Image) -> None:
@@ -153,7 +156,7 @@ class FA18Chornet(Aircraft):
             value = value.replace('`', '1').replace('~', '2')
         super().set_bios(selector, value, update)
 
-    def button_request(self, button: int) -> str:
+    def button_request(self, button: int, request: str = '\n') -> str:
         """
         Prepare F/A-18 Hornet specific DCS-BIOS request for button pressed.
 
@@ -161,6 +164,8 @@ class FA18Chornet(Aircraft):
 
         :param button: possible values 1-4
         :type: int
+        :param request: valid DCS-BIOS command as string
+        :type request: str
         :return: ready to send DCS-BIOS request
         :rtype: str
         """
@@ -168,14 +173,7 @@ class FA18Chornet(Aircraft):
                   2: 'UFC_COMM1_CHANNEL_SELECT INC\n',
                   3: 'UFC_COMM2_CHANNEL_SELECT DEC\n',
                   4: 'UFC_COMM2_CHANNEL_SELECT INC\n'}
-        debug(f'{self.__class__.__name__} Button: {button}')
-        try:
-            request = action[button].replace('\n', '')
-            debug(f'Request: {request}')
-            return f'{action[button]}'
-        except KeyError:
-            warning(f'{self.__class__.__name__} Wrong key, return empty request with new line')
-            return f'\n'
+        return super().button_request(button, action.get(button, '\n'))
 
 
 class F16C50(Aircraft):
@@ -235,7 +233,7 @@ class Ka50(Aircraft):
             'AP_HDG_HOLD_LED': {'class': 'IntegerBuffer', 'args': {'address': 0x1936, 'mask': 0x800, 'shift_by': 0xb}, 'value': int()},
             'AP_PITCH_HOLD_LED': {'class': 'IntegerBuffer', 'args': {'address': 0x1936, 'mask': 0x2000, 'shift_by': 0xd}, 'value': int()}}
 
-    def button_request(self, button: int) -> str:
+    def button_request(self, button: int, request: str = '\n') -> str:
         """
         Prepare Ka-50 Black Shark specific DCS-BIOS request for button pressed.
 
@@ -243,6 +241,8 @@ class Ka50(Aircraft):
 
         :param button: possible values 1-4
         :type: int
+        :param request: valid DCS-BIOS command as string
+        :type request: str
         :return: ready to send DCS-BIOS request
         :rtype: str
         """
@@ -250,14 +250,7 @@ class Ka50(Aircraft):
                   2: 'PVI_FIXPOINTS_BTN 1\nPVI_FIXPOINTS_BTN 0\n',
                   3: 'PVI_AIRFIELDS_BTN 1\nPVI_AIRFIELDS_BTN 0\n',
                   4: 'PVI_TARGETS_BTN 1\nPVI_TARGETS_BTN 0\n'}
-        debug(f'{self.__class__.__name__} Button: {button}')
-        try:
-            request = action[button].replace('\n', ' ')
-            debug(f'Request: {request}')
-            return f'{action[button]}'
-        except KeyError:
-            warning(f'{self.__class__.__name__} Wrong key, return empty request with new line')
-            return f'\n'
+        return super().button_request(button, action.get(button, '\n'))
 
     def prepare_image(self) -> Image.Image:
         """

--- a/dcspy/aircrafts.py
+++ b/dcspy/aircrafts.py
@@ -280,18 +280,18 @@ class Ka50(Aircraft):
 
     def _auto_pilot_switch(self, draw_obj: ImageDraw) -> None:
         """
-        Draw rectangle and add text form autopilot channel in correct coordinates.
+        Draw rectangle and add text for autopilot channels in correct coordinates.
 
         :param draw_obj: ImageDraw object form PIL
         """
-        for coord, ap_channel, turn_on in (({'rect': (111, 1, 124, 18), 'text': (114, 3)}, 'B', bool(self.get_bios("AP_BANK_HOLD_LED"))),
-                                           ({'rect': (128, 1, 141, 18), 'text': (130, 3)}, 'P', bool(self.get_bios("AP_PITCH_HOLD_LED"))),
-                                           ({'rect': (145, 1, 158, 18), 'text': (147, 3)}, 'F', bool(self.get_bios("AP_FD_LED"))),
-                                           ({'rect': (111, 22, 124, 39), 'text': (114, 24)}, 'H', bool(self.get_bios("AP_HDG_HOLD_LED"))),
-                                           ({'rect': (128, 22, 141, 39), 'text': (130, 24)}, 'A', bool(self.get_bios("AP_ALT_HOLD_LED")))):
+        for c_rect, c_text, ap_channel, turn_on in (((111, 1, 124, 18), (114, 3), 'B', self.get_bios('AP_BANK_HOLD_LED')),
+                                                    ((128, 1, 141, 18), (130, 3), 'P', self.get_bios('AP_PITCH_HOLD_LED')),
+                                                    ((145, 1, 158, 18), (147, 3), 'F', self.get_bios('AP_FD_LED')),
+                                                    ((111, 22, 124, 39), (114, 24), 'H', self.get_bios('AP_HDG_HOLD_LED')),
+                                                    ((128, 22, 141, 39), (130, 24), 'A', self.get_bios('AP_ALT_HOLD_LED'))):
             if turn_on:
-                draw_obj.rectangle(coord['rect'], 1, 1)
-                draw_obj.text(coord['text'], ap_channel, 0, FONT_16)
+                draw_obj.rectangle(c_rect, 1, 1)
+                draw_obj.text(c_text, ap_channel, 0, FONT_16)
             else:
-                draw_obj.rectangle(coord['rect'], 0, 1)
-                draw_obj.text(coord['text'], ap_channel, 1, FONT_16)
+                draw_obj.rectangle(c_rect, 0, 1)
+                draw_obj.text(c_text, ap_channel, 1, FONT_16)

--- a/dcspy/aircrafts.py
+++ b/dcspy/aircrafts.py
@@ -1,5 +1,5 @@
 from logging import debug, warning
-from typing import Dict
+from typing import Dict, Union
 
 from PIL import Image, ImageDraw
 
@@ -12,7 +12,9 @@ except ImportError:
     from typing import TypedDict
 
 
-BIOS_VALUE = TypedDict('BIOS_VALUE', {'addr': int, 'len': int, 'val': str})
+INT_BIOS = TypedDict('INT_BIOS', {'addr': int, 'mask': int, 'shift_by': int})
+STR_BIOS = TypedDict('STR_BIOS', {'addr': int, 'len': int, 'val': str})
+BIOS_VALUE = TypedDict('BIOS_VALUE', {'type': str, 'data': Union[INT_BIOS, STR_BIOS]})
 
 
 class Aircraft:

--- a/dcspy/aircrafts.py
+++ b/dcspy/aircrafts.py
@@ -1,6 +1,6 @@
 from logging import debug
 from string import whitespace
-from typing import Dict, Union
+from typing import Dict, Union, Tuple
 
 from PIL import Image, ImageDraw
 
@@ -277,6 +277,27 @@ class Ka50(Aircraft):
         line2 = f'{self.get_bios("l2_sign")}{text2} {self.get_bios("l2_point")}'
         draw.text((2, 3), line1, 1, FONT_16)
         draw.text((2, 24), line2, 1, FONT_16)
-        draw.text((108, 3), f'{self.get_bios("AP_BANK_HOLD_LED")} {self.get_bios("AP_PITCH_HOLD_LED")} {self.get_bios("AP_FD_LED")}', 1, FONT_16)
-        draw.text((108, 24), f'{self.get_bios("AP_HDG_HOLD_LED")} {self.get_bios("AP_ALT_HOLD_LED")}', 1, FONT_16)
+        Ka50._auto_pilot_switch(draw, (111, 1, 124, 18), (114, 3), 'B', bool(self.get_bios("AP_BANK_HOLD_LED")))
+        Ka50._auto_pilot_switch(draw, (128, 1, 141, 18), (130, 3), 'P', bool(self.get_bios("AP_PITCH_HOLD_LED")))
+        Ka50._auto_pilot_switch(draw, (145, 1, 158, 18), (147, 3), 'F', bool(self.get_bios("AP_FD_LED")))
+        Ka50._auto_pilot_switch(draw, (111, 22, 124, 39), (114, 24), 'H', bool(self.get_bios("AP_HDG_HOLD_LED")))
+        Ka50._auto_pilot_switch(draw, (128, 22, 141, 39), (130, 24), 'A', bool(self.get_bios("AP_ALT_HOLD_LED")))
         return img
+
+    @staticmethod
+    def _auto_pilot_switch(draw_obj: ImageDraw, rect_coord: Tuple[int, int, int, int], text_coord: Tuple[int, int], ap_channel: str, turn_on: bool) -> None:
+        """
+        Draw rectangle and add text form autopilot channel in correct coordinates.
+
+        :param draw_obj: ImageDraw object form PIL
+        :param rect_coord: where to draw rectangle
+        :param text_coord: where put AP channel name
+        :param ap_channel: Possible values: B, P, H, A and F
+        :param turn_on: AP channel should be turned on
+        """
+        if turn_on:
+            draw_obj.rectangle(rect_coord, 1, 1)
+            draw_obj.text(text_coord, ap_channel, 0, FONT_16)
+        else:
+            draw_obj.rectangle(rect_coord, 0, 1)
+            draw_obj.text(text_coord, ap_channel, 1, FONT_16)

--- a/dcspy/aircrafts.py
+++ b/dcspy/aircrafts.py
@@ -1,4 +1,5 @@
 from logging import debug
+from string import whitespace
 from typing import Dict, Union
 
 from PIL import Image, ImageDraw
@@ -43,7 +44,7 @@ class Aircraft:
         :rtype: str
         """
         debug(f'{self.__class__.__name__} Button: {button}')
-        debug(f'Request: {request.strip()}')
+        debug(f'Request: {request.replace(whitespace[2], " ")}')
         return request
 
     @staticmethod

--- a/dcspy/aircrafts.py
+++ b/dcspy/aircrafts.py
@@ -55,7 +55,7 @@ class Aircraft:
         :param value:
         :param update:
         """
-        self.bios_data[selector]['val'] = value
+        self.bios_data[selector]['value'] = value
         debug(f'{self.__class__.__name__} {selector} value: "{value}"')
         lcd_image = self.prepare_image()
         if update:
@@ -68,7 +68,7 @@ class Aircraft:
         :param selector:
         """
         try:
-            return self.bios_data[selector]['val']
+            return self.bios_data[selector]['value']
         except KeyError:
             return ''
 
@@ -83,22 +83,22 @@ class FA18Chornet(Aircraft):
         """
         super().__init__(width, height)
         self.bios_data: Dict[str, Dict['str': Union[str, int]]] = {
-            'ScratchpadStr1': {'addr': 0x744e, 'len': 2, 'val': str()},
-            'ScratchpadStr2': {'addr': 0x7450, 'len': 2, 'val': str()},
-            'ScratchpadNum': {'addr': 0x7446, 'len': 8, 'val': str()},
-            'OptionDisplay1': {'addr': 0x7432, 'len': 4, 'val': str()},
-            'OptionDisplay2': {'addr': 0x7436, 'len': 4, 'val': str()},
-            'OptionDisplay3': {'addr': 0x743a, 'len': 4, 'val': str()},
-            'OptionDisplay4': {'addr': 0x743e, 'len': 4, 'val': str()},
-            'OptionDisplay5': {'addr': 0x7442, 'len': 4, 'val': str()},
-            'COMM1': {'addr': 0x7424, 'len': 2, 'val': str()},
-            'COMM2': {'addr': 0x7426, 'len': 2, 'val': str()},
-            'OptionCueing1': {'addr': 0x7428, 'len': 1, 'val': str()},
-            'OptionCueing2': {'addr': 0x742a, 'len': 1, 'val': str()},
-            'OptionCueing3': {'addr': 0x742c, 'len': 1, 'val': str()},
-            'OptionCueing4': {'addr': 0x742e, 'len': 1, 'val': str()},
-            'OptionCueing5': {'addr': 0x7430, 'len': 1, 'val': str()},
-            'FuelTotal': {'addr': 0x748a, 'len': 6, 'val': str()}}
+            'ScratchpadStr1': {'address': 0x744e, 'length': 2, 'value': str()},
+            'ScratchpadStr2': {'address': 0x7450, 'length': 2, 'value': str()},
+            'ScratchpadNum': {'address': 0x7446, 'length': 8, 'value': str()},
+            'OptionDisplay1': {'address': 0x7432, 'length': 4, 'value': str()},
+            'OptionDisplay2': {'address': 0x7436, 'length': 4, 'value': str()},
+            'OptionDisplay3': {'address': 0x743a, 'length': 4, 'value': str()},
+            'OptionDisplay4': {'address': 0x743e, 'length': 4, 'value': str()},
+            'OptionDisplay5': {'address': 0x7442, 'length': 4, 'value': str()},
+            'COMM1': {'address': 0x7424, 'length': 2, 'value': str()},
+            'COMM2': {'address': 0x7426, 'length': 2, 'value': str()},
+            'OptionCueing1': {'address': 0x7428, 'length': 1, 'value': str()},
+            'OptionCueing2': {'address': 0x742a, 'length': 1, 'value': str()},
+            'OptionCueing3': {'address': 0x742c, 'length': 1, 'value': str()},
+            'OptionCueing4': {'address': 0x742e, 'length': 1, 'value': str()},
+            'OptionCueing5': {'address': 0x7430, 'length': 1, 'value': str()},
+            'FuelTotal': {'address': 0x748a, 'length': 6, 'value': str()}}
 
     def prepare_image(self) -> Image.Image:
         """
@@ -178,11 +178,11 @@ class F16C50(Aircraft):
         """
         super().__init__(width, height)
         self.bios_data: Dict[str, Dict['str': Union[str, int]]] = {
-            'DEDLine1': {'addr': 0x44fc, 'len': 50, 'val': str()},
-            'DEDLine2': {'addr': 0x452e, 'len': 50, 'val': str()},
-            'DEDLine3': {'addr': 0x4560, 'len': 50, 'val': str()},
-            'DEDLine4': {'addr': 0x4592, 'len': 50, 'val': str()},
-            'DEDLine5': {'addr': 0x45c4, 'len': 50, 'val': str()}}
+            'DEDLine1': {'address': 0x44fc, 'length': 50, 'value': str()},
+            'DEDLine2': {'address': 0x452e, 'length': 50, 'value': str()},
+            'DEDLine3': {'address': 0x4560, 'length': 50, 'value': str()},
+            'DEDLine4': {'address': 0x4592, 'length': 50, 'value': str()},
+            'DEDLine5': {'address': 0x45c4, 'length': 50, 'value': str()}}
 
     def prepare_image(self) -> Image.Image:
         """

--- a/dcspy/aircrafts.py
+++ b/dcspy/aircrafts.py
@@ -27,7 +27,7 @@ class Aircraft:
         """
         self.width = width
         self.height = height
-        self.bios_data: Dict[str, BIOS_VALUE] = {}
+        self.bios_data: Dict[str, Dict['str': Union[str, int]]] = {}
 
     def button_request(self, button: int) -> str:
         """
@@ -92,23 +92,23 @@ class FA18Chornet(Aircraft):
         :param height: LCD height
         """
         super().__init__(width, height)
-        self.bios_data: Dict[str, BIOS_VALUE] = {
-            'ScratchpadStr1': {'addr': 0x744e, 'len': 2, 'val': ''},
-            'ScratchpadStr2': {'addr': 0x7450, 'len': 2, 'val': ''},
-            'ScratchpadNum': {'addr': 0x7446, 'len': 8, 'val': ''},
-            'OptionDisplay1': {'addr': 0x7432, 'len': 4, 'val': ''},
-            'OptionDisplay2': {'addr': 0x7436, 'len': 4, 'val': ''},
-            'OptionDisplay3': {'addr': 0x743a, 'len': 4, 'val': ''},
-            'OptionDisplay4': {'addr': 0x743e, 'len': 4, 'val': ''},
-            'OptionDisplay5': {'addr': 0x7442, 'len': 4, 'val': ''},
-            'COMM1': {'addr': 0x7424, 'len': 2, 'val': ''},
-            'COMM2': {'addr': 0x7426, 'len': 2, 'val': ''},
-            'OptionCueing1': {'addr': 0x7428, 'len': 1, 'val': ''},
-            'OptionCueing2': {'addr': 0x742a, 'len': 1, 'val': ''},
-            'OptionCueing3': {'addr': 0x742c, 'len': 1, 'val': ''},
-            'OptionCueing4': {'addr': 0x742e, 'len': 1, 'val': ''},
-            'OptionCueing5': {'addr': 0x7430, 'len': 1, 'val': ''},
-            'FuelTotal': {'addr': 0x748a, 'len': 6, 'val': ''}}
+        self.bios_data: Dict[str, Dict['str': Union[str, int]]] = {
+            'ScratchpadStr1': {'addr': 0x744e, 'len': 2, 'val': str()},
+            'ScratchpadStr2': {'addr': 0x7450, 'len': 2, 'val': str()},
+            'ScratchpadNum': {'addr': 0x7446, 'len': 8, 'val': str()},
+            'OptionDisplay1': {'addr': 0x7432, 'len': 4, 'val': str()},
+            'OptionDisplay2': {'addr': 0x7436, 'len': 4, 'val': str()},
+            'OptionDisplay3': {'addr': 0x743a, 'len': 4, 'val': str()},
+            'OptionDisplay4': {'addr': 0x743e, 'len': 4, 'val': str()},
+            'OptionDisplay5': {'addr': 0x7442, 'len': 4, 'val': str()},
+            'COMM1': {'addr': 0x7424, 'len': 2, 'val': str()},
+            'COMM2': {'addr': 0x7426, 'len': 2, 'val': str()},
+            'OptionCueing1': {'addr': 0x7428, 'len': 1, 'val': str()},
+            'OptionCueing2': {'addr': 0x742a, 'len': 1, 'val': str()},
+            'OptionCueing3': {'addr': 0x742c, 'len': 1, 'val': str()},
+            'OptionCueing4': {'addr': 0x742e, 'len': 1, 'val': str()},
+            'OptionCueing5': {'addr': 0x7430, 'len': 1, 'val': str()},
+            'FuelTotal': {'addr': 0x748a, 'len': 6, 'val': str()}}
 
     def prepare_image(self) -> Image.Image:
         """
@@ -187,12 +187,12 @@ class F16C50(Aircraft):
         :param height: LCD height
         """
         super().__init__(width, height)
-        self.bios_data: Dict[str, BIOS_VALUE] = {
-            'DEDLine1': {'addr': 0x44fc, 'len': 50, 'val': ''},
-            'DEDLine2': {'addr': 0x452e, 'len': 50, 'val': ''},
-            'DEDLine3': {'addr': 0x4560, 'len': 50, 'val': ''},
-            'DEDLine4': {'addr': 0x4592, 'len': 50, 'val': ''},
-            'DEDLine5': {'addr': 0x45c4, 'len': 50, 'val': ''}}
+        self.bios_data: Dict[str, Dict['str': Union[str, int]]] = {
+            'DEDLine1': {'addr': 0x44fc, 'len': 50, 'val': str()},
+            'DEDLine2': {'addr': 0x452e, 'len': 50, 'val': str()},
+            'DEDLine3': {'addr': 0x4560, 'len': 50, 'val': str()},
+            'DEDLine4': {'addr': 0x4592, 'len': 50, 'val': str()},
+            'DEDLine5': {'addr': 0x45c4, 'len': 50, 'val': str()}}
 
     def prepare_image(self) -> Image.Image:
         """
@@ -218,23 +218,23 @@ class Ka50(Aircraft):
         :param height: LCD height
         """
         super().__init__(width, height)
-        self.bios_data: Dict[str, BIOS_VALUE] = {
-            'l1_apostr1': {'addr': 0x1934, 'len': 1, 'val': ''},
-            'l1_apostr2': {'addr': 0x1936, 'len': 1, 'val': ''},
-            'l1_point': {'addr': 0x1930, 'len': 1, 'val': ''},
-            'l1_sign': {'addr': 0x1920, 'len': 1, 'val': ''},
-            'l1_text': {'addr': 0x1924, 'len': 6, 'val': ''},
-            'l2_apostr1': {'addr': 0x1938, 'len': 1, 'val': ''},
-            'l2_apostr2': {'addr': 0x193a, 'len': 1, 'val': ''},
-            'l2_point': {'addr': 0x1932, 'len': 1, 'val': ''},
-            'l2_sign': {'addr': 0x1922, 'len': 1, 'val': ''},
-            'l2_text': {'addr': 0x192a, 'len': 6, 'val': ''}}
-        # todo: add handling IntegerBuffer to fetch data from BIOS
-        # 'AP_ALT_HOLD_LED': {'addr': 0x1936, 'len': 1, 'val': ''},
-        # 'AP_BANK_HOLD_LED': {'addr': 0x1936, 'len': 1, 'val': ''},
-        # 'AP_FD_LED': {'addr': 0x1936, 'len': 1, 'val': ''},
-        # 'AP_HDG_HOLD_LED': {'addr': 0x1936, 'len': 1, 'val': ''},
-        # 'AP_PITCH_HOLD_LED': {'addr': 0x1936, 'len': 1, 'val': ''}}
+        self.bios_data: Dict[str, Dict['str': Union[str, int]]] = {
+            'l1_apostr1': {'addr': 0x1934, 'len': 1, 'val': str()},
+            'l1_apostr2': {'addr': 0x1936, 'len': 1, 'val': str()},
+            'l1_point': {'addr': 0x1930, 'len': 1, 'val': str()},
+            'l1_sign': {'addr': 0x1920, 'len': 1, 'val': str()},
+            'l1_text': {'addr': 0x1924, 'len': 6, 'val': str()},
+            'l2_apostr1': {'addr': 0x1938, 'len': 1, 'val': str()},
+            'l2_apostr2': {'addr': 0x193a, 'len': 1, 'val': str()},
+            'l2_point': {'addr': 0x1932, 'len': 1, 'val': str()},
+            'l2_sign': {'addr': 0x1922, 'len': 1, 'val': str()},
+            'l2_text': {'addr': 0x192a, 'len': 6, 'val': str()}}
+            # todo: add handling IntegerBuffer to fetch data from BIOS
+            # 'AP_ALT_HOLD_LED': {'addr': 0x1936, 'len': 1, 'val': int()},
+            # 'AP_BANK_HOLD_LED': {'addr': 0x1936, 'len': 1, 'val': int()},
+            # 'AP_FD_LED': {'addr': 0x1936, 'len': 1, 'val': int()},
+            # 'AP_HDG_HOLD_LED': {'addr': 0x1936, 'len': 1, 'val': int()},
+            # 'AP_PITCH_HOLD_LED': {'addr': 0x1936, 'len': 1, 'val': int()}}
 
     def button_request(self, button: int) -> str:
         """

--- a/dcspy/aircrafts.py
+++ b/dcspy/aircrafts.py
@@ -1,6 +1,6 @@
 from logging import debug
 from string import whitespace
-from typing import Dict, Union, Tuple
+from typing import Dict, Union
 
 from PIL import Image, ImageDraw
 

--- a/dcspy/aircrafts.py
+++ b/dcspy/aircrafts.py
@@ -275,26 +275,23 @@ class Ka50(Aircraft):
         line2 = f'{self.get_bios("l2_sign")}{text2} {self.get_bios("l2_point")}'
         draw.text((2, 3), line1, 1, FONT_16)
         draw.text((2, 24), line2, 1, FONT_16)
-        Ka50._auto_pilot_switch(draw, {'rect': (111, 1, 124, 18), 'text': (114, 3)}, 'B', bool(self.get_bios("AP_BANK_HOLD_LED")))
-        Ka50._auto_pilot_switch(draw, {'rect': (128, 1, 141, 18), 'text': (130, 3)}, 'P', bool(self.get_bios("AP_PITCH_HOLD_LED")))
-        Ka50._auto_pilot_switch(draw, {'rect': (145, 1, 158, 18), 'text': (147, 3)}, 'F', bool(self.get_bios("AP_FD_LED")))
-        Ka50._auto_pilot_switch(draw, {'rect': (111, 22, 124, 39), 'text': (114, 24)}, 'H', bool(self.get_bios("AP_HDG_HOLD_LED")))
-        Ka50._auto_pilot_switch(draw, {'rect': (128, 22, 141, 39), 'text': (130, 24)}, 'A', bool(self.get_bios("AP_ALT_HOLD_LED")))
+        self._auto_pilot_switch(draw)
         return img
 
-    @staticmethod
-    def _auto_pilot_switch(draw_obj: ImageDraw, coord: Dict[str, Tuple[int, ...]], ap_channel: str, turn_on: bool) -> None:
+    def _auto_pilot_switch(self, draw_obj: ImageDraw) -> None:
         """
         Draw rectangle and add text form autopilot channel in correct coordinates.
 
         :param draw_obj: ImageDraw object form PIL
-        :param coord: coordinates where to draw rectangle and where put AP channel name
-        :param ap_channel: Possible values: B, P, H, A and F
-        :param turn_on: AP channel should be turned on
         """
-        if turn_on:
-            draw_obj.rectangle(coord['rect'], 1, 1)
-            draw_obj.text(coord['text'], ap_channel, 0, FONT_16)
-        else:
-            draw_obj.rectangle(coord['rect'], 0, 1)
-            draw_obj.text(coord['text'], ap_channel, 1, FONT_16)
+        for coord, ap_channel, turn_on in (({'rect': (111, 1, 124, 18), 'text': (114, 3)}, 'B', bool(self.get_bios("AP_BANK_HOLD_LED"))),
+                                           ({'rect': (128, 1, 141, 18), 'text': (130, 3)}, 'P', bool(self.get_bios("AP_PITCH_HOLD_LED"))),
+                                           ({'rect': (145, 1, 158, 18), 'text': (147, 3)}, 'F', bool(self.get_bios("AP_FD_LED"))),
+                                           ({'rect': (111, 22, 124, 39), 'text': (114, 24)}, 'H', bool(self.get_bios("AP_HDG_HOLD_LED"))),
+                                           ({'rect': (128, 22, 141, 39), 'text': (130, 24)}, 'A', bool(self.get_bios("AP_ALT_HOLD_LED")))):
+            if turn_on:
+                draw_obj.rectangle(coord['rect'], 1, 1)
+                draw_obj.text(coord['text'], ap_channel, 0, FONT_16)
+            else:
+                draw_obj.rectangle(coord['rect'], 0, 1)
+                draw_obj.text(coord['text'], ap_channel, 1, FONT_16)

--- a/dcspy/aircrafts.py
+++ b/dcspy/aircrafts.py
@@ -275,27 +275,26 @@ class Ka50(Aircraft):
         line2 = f'{self.get_bios("l2_sign")}{text2} {self.get_bios("l2_point")}'
         draw.text((2, 3), line1, 1, FONT_16)
         draw.text((2, 24), line2, 1, FONT_16)
-        Ka50._auto_pilot_switch(draw, (111, 1, 124, 18), (114, 3), 'B', bool(self.get_bios("AP_BANK_HOLD_LED")))
-        Ka50._auto_pilot_switch(draw, (128, 1, 141, 18), (130, 3), 'P', bool(self.get_bios("AP_PITCH_HOLD_LED")))
-        Ka50._auto_pilot_switch(draw, (145, 1, 158, 18), (147, 3), 'F', bool(self.get_bios("AP_FD_LED")))
-        Ka50._auto_pilot_switch(draw, (111, 22, 124, 39), (114, 24), 'H', bool(self.get_bios("AP_HDG_HOLD_LED")))
-        Ka50._auto_pilot_switch(draw, (128, 22, 141, 39), (130, 24), 'A', bool(self.get_bios("AP_ALT_HOLD_LED")))
+        Ka50._auto_pilot_switch(draw, {'rect': (111, 1, 124, 18), 'text': (114, 3)}, 'B', bool(self.get_bios("AP_BANK_HOLD_LED")))
+        Ka50._auto_pilot_switch(draw, {'rect': (128, 1, 141, 18), 'text': (130, 3)}, 'P', bool(self.get_bios("AP_PITCH_HOLD_LED")))
+        Ka50._auto_pilot_switch(draw, {'rect': (145, 1, 158, 18), 'text': (147, 3)}, 'F', bool(self.get_bios("AP_FD_LED")))
+        Ka50._auto_pilot_switch(draw, {'rect': (111, 22, 124, 39), 'text': (114, 24)}, 'H', bool(self.get_bios("AP_HDG_HOLD_LED")))
+        Ka50._auto_pilot_switch(draw, {'rect': (128, 22, 141, 39), 'text': (130, 24)}, 'A', bool(self.get_bios("AP_ALT_HOLD_LED")))
         return img
 
     @staticmethod
-    def _auto_pilot_switch(draw_obj: ImageDraw, rect_coord: Tuple[int, int, int, int], text_coord: Tuple[int, int], ap_channel: str, turn_on: bool) -> None:
+    def _auto_pilot_switch(draw_obj: ImageDraw, coord: Dict[str, Tuple[int, ...]], ap_channel: str, turn_on: bool) -> None:
         """
         Draw rectangle and add text form autopilot channel in correct coordinates.
 
         :param draw_obj: ImageDraw object form PIL
-        :param rect_coord: where to draw rectangle
-        :param text_coord: where put AP channel name
+        :param coord: coordinates where to draw rectangle and where put AP channel name
         :param ap_channel: Possible values: B, P, H, A and F
         :param turn_on: AP channel should be turned on
         """
         if turn_on:
-            draw_obj.rectangle(rect_coord, 1, 1)
-            draw_obj.text(text_coord, ap_channel, 0, FONT_16)
+            draw_obj.rectangle(coord['rect'], 1, 1)
+            draw_obj.text(coord['text'], ap_channel, 0, FONT_16)
         else:
-            draw_obj.rectangle(rect_coord, 0, 1)
-            draw_obj.text(text_coord, ap_channel, 1, FONT_16)
+            draw_obj.rectangle(coord['rect'], 0, 1)
+            draw_obj.text(coord['text'], ap_channel, 1, FONT_16)

--- a/dcspy/aircrafts.py
+++ b/dcspy/aircrafts.py
@@ -155,7 +155,7 @@ class FA18Chornet(Aircraft):
 
     def button_request(self, button: int) -> str:
         """
-        Prepare specific DCS-BIOS request for button pressed.
+        Prepare F/A-18 Hornet specific DCS-BIOS request for button pressed.
 
         If button is out of scope new line is return.
 
@@ -237,7 +237,7 @@ class Ka50(Aircraft):
 
     def button_request(self, button: int) -> str:
         """
-        Prepare specific DCS-BIOS request for button pressed.
+        Prepare Ka-50 Black Shark specific DCS-BIOS request for button pressed.
 
         If button is out of scope new line is return.
 

--- a/dcspy/aircrafts.py
+++ b/dcspy/aircrafts.py
@@ -13,9 +13,7 @@ except ImportError:
     from typing import TypedDict
 
 
-INT_BIOS = TypedDict('INT_BIOS', {'addr': int, 'mask': int, 'shift_by': int})
-STR_BIOS = TypedDict('STR_BIOS', {'addr': int, 'len': int})
-BIOS_VALUE = TypedDict('BIOS_VALUE', {'class': str, 'args': Union[INT_BIOS, STR_BIOS], 'value': Union[int, str]})
+BIOS_VALUE = TypedDict('BIOS_VALUE', {'class': str, 'args': Dict[str, int], 'value': Union[int, str]})
 
 
 class Aircraft:
@@ -267,8 +265,8 @@ class Ka50(Aircraft):
         draw.rectangle((0, 22, 85, 39), 0, 1)
         draw.rectangle((88, 1, 103, 18), 0, 1)
         draw.rectangle((88, 22, 103, 39), 0, 1)
-        l1_text = self.get_bios('l1_text')
-        l2_text = self.get_bios('l2_text')
+        l1_text = str(self.get_bios('l1_text'))
+        l2_text = str(self.get_bios('l2_text'))
         if l1_text:
             text1 = f'{l1_text[-6:-3]}{self.get_bios("l1_apostr1")}{l1_text[-3:-1]}{self.get_bios("l1_apostr2")}{l1_text[-1]}'
         if l2_text:

--- a/dcspy/aircrafts.py
+++ b/dcspy/aircrafts.py
@@ -6,6 +6,16 @@ from PIL import Image, ImageDraw
 from dcspy import FONT_11, FONT_16
 from dcspy.sdk import lcd_sdk
 
+try:
+    from typing_extensions import TypedDict
+except ImportError:
+    from typing import TypedDict
+
+
+INT_BIOS = TypedDict('INT_BIOS', {'addr': int, 'mask': int, 'shift_by': int})
+STR_BIOS = TypedDict('STR_BIOS', {'addr': int, 'len': int})
+BIOS_VALUE = TypedDict('BIOS_VALUE', {'class': str, 'args': Union[INT_BIOS, STR_BIOS], 'value': Union[int, str]})
+
 
 class Aircraft:
     def __init__(self, width: int, height: int) -> None:
@@ -17,7 +27,7 @@ class Aircraft:
         """
         self.width = width
         self.height = height
-        self.bios_data: Dict[str, Dict[str, Union[str, int]]] = {}
+        self.bios_data: Dict[str, BIOS_VALUE] = {}
 
     def button_request(self, button: int) -> str:
         """
@@ -82,23 +92,23 @@ class FA18Chornet(Aircraft):
         :param height: LCD height
         """
         super().__init__(width, height)
-        self.bios_data: Dict[str, Dict[str, Union[str, int]]] = {
-            'ScratchpadStr1': {'address': 0x744e, 'length': 2, 'value': str()},
-            'ScratchpadStr2': {'address': 0x7450, 'length': 2, 'value': str()},
-            'ScratchpadNum': {'address': 0x7446, 'length': 8, 'value': str()},
-            'OptionDisplay1': {'address': 0x7432, 'length': 4, 'value': str()},
-            'OptionDisplay2': {'address': 0x7436, 'length': 4, 'value': str()},
-            'OptionDisplay3': {'address': 0x743a, 'length': 4, 'value': str()},
-            'OptionDisplay4': {'address': 0x743e, 'length': 4, 'value': str()},
-            'OptionDisplay5': {'address': 0x7442, 'length': 4, 'value': str()},
-            'COMM1': {'address': 0x7424, 'length': 2, 'value': str()},
-            'COMM2': {'address': 0x7426, 'length': 2, 'value': str()},
-            'OptionCueing1': {'address': 0x7428, 'length': 1, 'value': str()},
-            'OptionCueing2': {'address': 0x742a, 'length': 1, 'value': str()},
-            'OptionCueing3': {'address': 0x742c, 'length': 1, 'value': str()},
-            'OptionCueing4': {'address': 0x742e, 'length': 1, 'value': str()},
-            'OptionCueing5': {'address': 0x7430, 'length': 1, 'value': str()},
-            'FuelTotal': {'address': 0x748a, 'length': 6, 'value': str()}}
+        self.bios_data: Dict[str, BIOS_VALUE] = {
+            'ScratchpadStr1': {'class': 'StringBuffer', 'args': {'address': 0x744e, 'length': 2}, 'value': str()},
+            'ScratchpadStr2': {'class': 'StringBuffer', 'args': {'address': 0x7450, 'length': 2}, 'value': str()},
+            'ScratchpadNum': {'class': 'StringBuffer', 'args': {'address': 0x7446, 'length': 8}, 'value': str()},
+            'OptionDisplay1': {'class': 'StringBuffer', 'args': {'address': 0x7432, 'length': 4}, 'value': str()},
+            'OptionDisplay2': {'class': 'StringBuffer', 'args': {'address': 0x7436, 'length': 4}, 'value': str()},
+            'OptionDisplay3': {'class': 'StringBuffer', 'args': {'address': 0x743a, 'length': 4}, 'value': str()},
+            'OptionDisplay4': {'class': 'StringBuffer', 'args': {'address': 0x743e, 'length': 4}, 'value': str()},
+            'OptionDisplay5': {'class': 'StringBuffer', 'args': {'address': 0x7442, 'length': 4}, 'value': str()},
+            'COMM1': {'class': 'StringBuffer', 'args': {'address': 0x7424, 'length': 2}, 'value': str()},
+            'COMM2': {'class': 'StringBuffer', 'args': {'address': 0x7426, 'length': 2}, 'value': str()},
+            'OptionCueing1': {'class': 'StringBuffer', 'args': {'address': 0x7428, 'length': 1}, 'value': str()},
+            'OptionCueing2': {'class': 'StringBuffer', 'args': {'address': 0x742a, 'length': 1}, 'value': str()},
+            'OptionCueing3': {'class': 'StringBuffer', 'args': {'address': 0x742c, 'length': 1}, 'value': str()},
+            'OptionCueing4': {'class': 'StringBuffer', 'args': {'address': 0x742e, 'length': 1}, 'value': str()},
+            'OptionCueing5': {'class': 'StringBuffer', 'args': {'address': 0x7430, 'length': 1}, 'value': str()},
+            'FuelTotal': {'class': 'StringBuffer', 'args': {'address': 0x748a, 'length': 6}, 'value': str()}}
 
     def prepare_image(self) -> Image.Image:
         """
@@ -177,12 +187,12 @@ class F16C50(Aircraft):
         :param height: LCD height
         """
         super().__init__(width, height)
-        self.bios_data: Dict[str, Dict[str, Union[str, int]]] = {
-            'DEDLine1': {'address': 0x44fc, 'length': 50, 'value': str()},
-            'DEDLine2': {'address': 0x452e, 'length': 50, 'value': str()},
-            'DEDLine3': {'address': 0x4560, 'length': 50, 'value': str()},
-            'DEDLine4': {'address': 0x4592, 'length': 50, 'value': str()},
-            'DEDLine5': {'address': 0x45c4, 'length': 50, 'value': str()}}
+        self.bios_data: Dict[str, BIOS_VALUE] = {
+            'DEDLine1': {'class': 'StringBuffer', 'args': {'address': 0x44fc, 'length': 50}, 'value': str()},
+            'DEDLine2': {'class': 'StringBuffer', 'args': {'address': 0x452e, 'length': 50}, 'value': str()},
+            'DEDLine3': {'class': 'StringBuffer', 'args': {'address': 0x4560, 'length': 50}, 'value': str()},
+            'DEDLine4': {'class': 'StringBuffer', 'args': {'address': 0x4592, 'length': 50}, 'value': str()},
+            'DEDLine5': {'class': 'StringBuffer', 'args': {'address': 0x45c4, 'length': 50}, 'value': str()}}
 
     def prepare_image(self) -> Image.Image:
         """
@@ -208,22 +218,22 @@ class Ka50(Aircraft):
         :param height: LCD height
         """
         super().__init__(width, height)
-        self.bios_data: Dict[str, Dict[str, Union[str, int]]] = {
-            'l1_apostr1': {'address': 0x1934, 'length': 1, 'value': str()},
-            'l1_apostr2': {'address': 0x1936, 'length': 1, 'value': str()},
-            'l1_point': {'address': 0x1930, 'length': 1, 'value': str()},
-            'l1_sign': {'address': 0x1920, 'length': 1, 'value': str()},
-            'l1_text': {'address': 0x1924, 'length': 6, 'value': str()},
-            'l2_apostr1': {'address': 0x1938, 'length': 1, 'value': str()},
-            'l2_apostr2': {'address': 0x193a, 'length': 1, 'value': str()},
-            'l2_point': {'address': 0x1932, 'length': 1, 'value': str()},
-            'l2_sign': {'address': 0x1922, 'length': 1, 'value': str()},
-            'l2_text': {'address': 0x192a, 'length': 6, 'value': str()},
-            'AP_ALT_HOLD_LED': {'address': 0x1936, 'mask': 0x8000, 'shift_by': 0xf, 'value': int()},
-            'AP_BANK_HOLD_LED': {'address': 0x1936, 'mask': 0x200, 'shift_by': 0x9, 'value': int()},
-            'AP_FD_LED': {'address': 0x1938, 'mask': 0x200, 'shift_by': 0x9, 'value': int()},
-            'AP_HDG_HOLD_LED': {'address': 0x1936, 'mask': 0x800, 'shift_by': 0xb, 'value': int()},
-            'AP_PITCH_HOLD_LED': {'address': 0x1936, 'mask': 0x2000, 'shift_by': 0xd, 'value': int()}}
+        self.bios_data: Dict[str, BIOS_VALUE] = {
+            'l1_apostr1': {'class': 'StringBuffer', 'args': {'address': 0x1934, 'length': 1}, 'value': str()},
+            'l1_apostr2': {'class': 'StringBuffer', 'args': {'address': 0x1936, 'length': 1}, 'value': str()},
+            'l1_point': {'class': 'StringBuffer', 'args': {'address': 0x1930, 'length': 1}, 'value': str()},
+            'l1_sign': {'class': 'StringBuffer', 'args': {'address': 0x1920, 'length': 1}, 'value': str()},
+            'l1_text': {'class': 'StringBuffer', 'args': {'address': 0x1924, 'length': 6}, 'value': str()},
+            'l2_apostr1': {'class': 'StringBuffer', 'args': {'address': 0x1938, 'length': 1}, 'value': str()},
+            'l2_apostr2': {'class': 'StringBuffer', 'args': {'address': 0x193a, 'length': 1}, 'value': str()},
+            'l2_point': {'class': 'StringBuffer', 'args': {'address': 0x1932, 'length': 1}, 'value': str()},
+            'l2_sign': {'class': 'StringBuffer', 'args': {'address': 0x1922, 'length': 1}, 'value': str()},
+            'l2_text': {'class': 'StringBuffer', 'args': {'address': 0x192a, 'length': 6}, 'value': str()},
+            'AP_ALT_HOLD_LED': {'class': 'IntegerBuffer', 'args': {'address': 0x1936, 'mask': 0x8000, 'shift_by': 0xf}, 'value': int()},
+            'AP_BANK_HOLD_LED': {'class': 'IntegerBuffer', 'args': {'address': 0x1936, 'mask': 0x200, 'shift_by': 0x9}, 'value': int()},
+            'AP_FD_LED': {'class': 'IntegerBuffer', 'args': {'address': 0x1938, 'mask': 0x200, 'shift_by': 0x9}, 'value': int()},
+            'AP_HDG_HOLD_LED': {'class': 'IntegerBuffer', 'args': {'address': 0x1936, 'mask': 0x800, 'shift_by': 0xb}, 'value': int()},
+            'AP_PITCH_HOLD_LED': {'class': 'IntegerBuffer', 'args': {'address': 0x1936, 'mask': 0x2000, 'shift_by': 0xd}, 'value': int()}}
 
     def button_request(self, button: int) -> str:
         """

--- a/dcspy/aircrafts.py
+++ b/dcspy/aircrafts.py
@@ -75,7 +75,7 @@ class Aircraft:
         if update:
             self.update_display(lcd_image)
 
-    def get_bios(self, selector: str) -> str:
+    def get_bios(self, selector: str) -> Union[str, int]:
         """
         Get value for DCS-BIOS selector.
 

--- a/dcspy/aircrafts.py
+++ b/dcspy/aircrafts.py
@@ -219,12 +219,12 @@ class Ka50(Aircraft):
             'l2_point': {'addr': 0x1932, 'len': 1, 'val': str()},
             'l2_sign': {'addr': 0x1922, 'len': 1, 'val': str()},
             'l2_text': {'addr': 0x192a, 'len': 6, 'val': str()}}
-            # todo: add handling IntegerBuffer to fetch data from BIOS
-            # 'AP_ALT_HOLD_LED': {'addr': 0x1936, 'len': 1, 'val': int()},
-            # 'AP_BANK_HOLD_LED': {'addr': 0x1936, 'len': 1, 'val': int()},
-            # 'AP_FD_LED': {'addr': 0x1936, 'len': 1, 'val': int()},
-            # 'AP_HDG_HOLD_LED': {'addr': 0x1936, 'len': 1, 'val': int()},
-            # 'AP_PITCH_HOLD_LED': {'addr': 0x1936, 'len': 1, 'val': int()}}
+        # todo: add handling IntegerBuffer to fetch data from BIOS
+        # 'AP_ALT_HOLD_LED': {'addr': 0x1936, 'len': 1, 'val': int()},
+        # 'AP_BANK_HOLD_LED': {'addr': 0x1936, 'len': 1, 'val': int()},
+        # 'AP_FD_LED': {'addr': 0x1936, 'len': 1, 'val': int()},
+        # 'AP_HDG_HOLD_LED': {'addr': 0x1936, 'len': 1, 'val': int()},
+        # 'AP_PITCH_HOLD_LED': {'addr': 0x1936, 'len': 1, 'val': int()}}
 
     def button_request(self, button: int) -> str:
         """

--- a/dcspy/aircrafts.py
+++ b/dcspy/aircrafts.py
@@ -209,22 +209,21 @@ class Ka50(Aircraft):
         """
         super().__init__(width, height)
         self.bios_data: Dict[str, Dict['str': Union[str, int]]] = {
-            'l1_apostr1': {'addr': 0x1934, 'len': 1, 'val': str()},
-            'l1_apostr2': {'addr': 0x1936, 'len': 1, 'val': str()},
-            'l1_point': {'addr': 0x1930, 'len': 1, 'val': str()},
-            'l1_sign': {'addr': 0x1920, 'len': 1, 'val': str()},
-            'l1_text': {'addr': 0x1924, 'len': 6, 'val': str()},
-            'l2_apostr1': {'addr': 0x1938, 'len': 1, 'val': str()},
-            'l2_apostr2': {'addr': 0x193a, 'len': 1, 'val': str()},
-            'l2_point': {'addr': 0x1932, 'len': 1, 'val': str()},
-            'l2_sign': {'addr': 0x1922, 'len': 1, 'val': str()},
-            'l2_text': {'addr': 0x192a, 'len': 6, 'val': str()}}
-        # todo: add handling IntegerBuffer to fetch data from BIOS
-        # 'AP_ALT_HOLD_LED': {'addr': 0x1936, 'len': 1, 'val': int()},
-        # 'AP_BANK_HOLD_LED': {'addr': 0x1936, 'len': 1, 'val': int()},
-        # 'AP_FD_LED': {'addr': 0x1936, 'len': 1, 'val': int()},
-        # 'AP_HDG_HOLD_LED': {'addr': 0x1936, 'len': 1, 'val': int()},
-        # 'AP_PITCH_HOLD_LED': {'addr': 0x1936, 'len': 1, 'val': int()}}
+            'l1_apostr1': {'address': 0x1934, 'length': 1, 'value': str()},
+            'l1_apostr2': {'address': 0x1936, 'length': 1, 'value': str()},
+            'l1_point': {'address': 0x1930, 'length': 1, 'value': str()},
+            'l1_sign': {'address': 0x1920, 'length': 1, 'value': str()},
+            'l1_text': {'address': 0x1924, 'length': 6, 'value': str()},
+            'l2_apostr1': {'address': 0x1938, 'length': 1, 'value': str()},
+            'l2_apostr2': {'address': 0x193a, 'length': 1, 'value': str()},
+            'l2_point': {'address': 0x1932, 'length': 1, 'value': str()},
+            'l2_sign': {'address': 0x1922, 'length': 1, 'value': str()},
+            'l2_text': {'address': 0x192a, 'length': 6, 'value': str()},
+            'AP_ALT_HOLD_LED': {'address': 0x1936, 'mask': 0x8000, 'shift_by': 0xf, 'value': int()},
+            'AP_BANK_HOLD_LED': {'address': 0x1936, 'mask': 0x200, 'shift_by': 0x9, 'value': int()},
+            'AP_FD_LED': {'address': 0x1938, 'mask': 0x200, 'shift_by': 0x9, 'value': int()},
+            'AP_HDG_HOLD_LED': {'address': 0x1936, 'mask': 0x800, 'shift_by': 0xb, 'value': int()},
+            'AP_PITCH_HOLD_LED': {'address': 0x1936, 'mask': 0x2000, 'shift_by': 0xd, 'value': int()}}
 
     def button_request(self, button: int) -> str:
         """
@@ -274,4 +273,6 @@ class Ka50(Aircraft):
         line2 = f'{self.get_bios("l2_sign")}{text2} {self.get_bios("l2_point")}'
         draw.text((2, 3), line1, 1, FONT_16)
         draw.text((2, 24), line2, 1, FONT_16)
+        draw.text((108, 3), f'{self.get_bios("AP_BANK_HOLD_LED")} {self.get_bios("AP_PITCH_HOLD_LED")} {self.get_bios("AP_FD_LED")}', 1, FONT_16)
+        draw.text((108, 24), f'{self.get_bios("AP_HDG_HOLD_LED")} {self.get_bios("AP_ALT_HOLD_LED")}', 1, FONT_16)
         return img

--- a/dcspy/aircrafts.py
+++ b/dcspy/aircrafts.py
@@ -17,7 +17,7 @@ class Aircraft:
         """
         self.width = width
         self.height = height
-        self.bios_data: Dict[str, Dict[str: Union[str, int]]] = {}
+        self.bios_data: Dict[str, Dict[str, Union[str, int]]] = {}
 
     def button_request(self, button: int) -> str:
         """
@@ -82,7 +82,7 @@ class FA18Chornet(Aircraft):
         :param height: LCD height
         """
         super().__init__(width, height)
-        self.bios_data: Dict[str, Dict[str: Union[str, int]]] = {
+        self.bios_data: Dict[str, Dict[str, Union[str, int]]] = {
             'ScratchpadStr1': {'address': 0x744e, 'length': 2, 'value': str()},
             'ScratchpadStr2': {'address': 0x7450, 'length': 2, 'value': str()},
             'ScratchpadNum': {'address': 0x7446, 'length': 8, 'value': str()},
@@ -177,7 +177,7 @@ class F16C50(Aircraft):
         :param height: LCD height
         """
         super().__init__(width, height)
-        self.bios_data: Dict[str, Dict[str: Union[str, int]]] = {
+        self.bios_data: Dict[str, Dict[str, Union[str, int]]] = {
             'DEDLine1': {'address': 0x44fc, 'length': 50, 'value': str()},
             'DEDLine2': {'address': 0x452e, 'length': 50, 'value': str()},
             'DEDLine3': {'address': 0x4560, 'length': 50, 'value': str()},
@@ -208,7 +208,7 @@ class Ka50(Aircraft):
         :param height: LCD height
         """
         super().__init__(width, height)
-        self.bios_data: Dict[str, Dict[str: Union[str, int]]] = {
+        self.bios_data: Dict[str, Dict[str, Union[str, int]]] = {
             'l1_apostr1': {'address': 0x1934, 'length': 1, 'value': str()},
             'l1_apostr2': {'address': 0x1936, 'length': 1, 'value': str()},
             'l1_point': {'address': 0x1930, 'length': 1, 'value': str()},

--- a/dcspy/dcsbios.py
+++ b/dcspy/dcsbios.py
@@ -1,3 +1,4 @@
+from functools import partial
 from struct import pack
 from typing import Callable, Set
 
@@ -126,7 +127,7 @@ class StringBuffer:
         self.callbacks: Set[Callable] = set()
         if callback:
             self.callbacks.add(callback)
-        parser.write_callbacks.add(lambda addr, data: self.on_dcsbios_write(address=addr, data=data))
+        parser.write_callbacks.add(partial(self.on_dcsbios_write))
 
     def set_char(self, index, char) -> None:
         """
@@ -177,7 +178,7 @@ class IntegerBuffer:
         self.callbacks: Set[Callable] = set()
         if callback:
             self.callbacks.add(callback)
-        parser.write_callbacks.add(lambda addr, data: self.on_dcsbios_write(address=addr, data=data))
+        parser.write_callbacks.add(partial(self.on_dcsbios_write))
 
     def on_dcsbios_write(self, address: int, data: int) -> None:
         """

--- a/dcspy/logitech.py
+++ b/dcspy/logitech.py
@@ -88,9 +88,13 @@ class G13:
         for field_name, proto_data in self.plane.bios_data.items():
             buff_params = {param: value for param, value in proto_data.items() if param != 'value'}
             if isinstance(proto_data['value'], str):
-                StringBuffer(parser=self.parser, callback=partial(self.plane.set_bios, field_name), **buff_params)
+                buf = getattr(import_module('dcspy.dcsbios'), 'StringBuffer')
+                buf(parser=self.parser, callback=partial(self.plane.set_bios, field_name), **buff_params)
+                # StringBuffer(parser=self.parser, callback=partial(self.plane.set_bios, field_name), **buff_params)
             else:  # int
-                IntegerBuffer(parser=self.parser, callback=partial(self.plane.set_bios, field_name), **buff_params)
+                buf = getattr(import_module('dcspy.dcsbios'), 'IntegerBuffer')
+                buf(parser=self.parser, callback=partial(self.plane.set_bios, field_name), **buff_params)
+                # IntegerBuffer(parser=self.parser, callback=partial(self.plane.set_bios, field_name), **buff_params)
 
     def check_buttons(self) -> int:
         """

--- a/dcspy/logitech.py
+++ b/dcspy/logitech.py
@@ -86,8 +86,8 @@ class G13:
         self.plane = getattr(import_module('dcspy.aircrafts'), self.plane_name)(self.g13_lcd.width, self.g13_lcd.height)
         debug(f'Dynamic load of: {self.plane_name} as {SUPPORTED_CRAFTS[self.plane_name]}')
         for field_name, proto_data in self.plane.bios_data.items():
-            buff_params = {param: value for param, value in proto_data.items() if param != 'val'}
-            if isinstance(proto_data['val'], str):
+            buff_params = {param: value for param, value in proto_data.items() if param != 'value'}
+            if isinstance(proto_data['value'], str):
                 StringBuffer(parser=self.parser, callback=partial(self.plane.set_bios, field_name), **buff_params)
             else:  # int
                 IntegerBuffer(parser=self.parser, callback=partial(self.plane.set_bios, field_name), **buff_params)

--- a/dcspy/logitech.py
+++ b/dcspy/logitech.py
@@ -9,7 +9,7 @@ from PIL import Image, ImageDraw
 
 from dcspy import SUPPORTED_CRAFTS, FONT_11, LcdSize
 from dcspy.aircrafts import Aircraft
-from dcspy.dcsbios import StringBuffer, ProtocolParser, IntegerBuffer
+from dcspy.dcsbios import ProtocolParser
 from dcspy.sdk import lcd_sdk
 
 
@@ -21,7 +21,7 @@ class G13:
         :param parser_hook: BSC-BIOS parser
         :type parser_hook: ProtocolParser
         """
-        StringBuffer(parser_hook, 0x0000, 16, partial(self.detecting_plane))
+        getattr(import_module('dcspy.dcsbios'), 'StringBuffer')(parser_hook, 0x0000, 16, partial(self.detecting_plane))
         self._display: List[str] = list()
         self.g13_lcd = LcdSize(width=lcd_sdk.MONO_WIDTH, height=lcd_sdk.MONO_HEIGHT)
         self.parser = parser_hook

--- a/dcspy/logitech.py
+++ b/dcspy/logitech.py
@@ -86,15 +86,8 @@ class G13:
         self.plane = getattr(import_module('dcspy.aircrafts'), self.plane_name)(self.g13_lcd.width, self.g13_lcd.height)
         debug(f'Dynamic load of: {self.plane_name} as {SUPPORTED_CRAFTS[self.plane_name]}')
         for field_name, proto_data in self.plane.bios_data.items():
-            buff_params = {param: value for param, value in proto_data.items() if param != 'value'}
-            if isinstance(proto_data['value'], str):
-                buf = getattr(import_module('dcspy.dcsbios'), 'StringBuffer')
-                buf(parser=self.parser, callback=partial(self.plane.set_bios, field_name), **buff_params)
-                # StringBuffer(parser=self.parser, callback=partial(self.plane.set_bios, field_name), **buff_params)
-            else:  # int
-                buf = getattr(import_module('dcspy.dcsbios'), 'IntegerBuffer')
-                buf(parser=self.parser, callback=partial(self.plane.set_bios, field_name), **buff_params)
-                # IntegerBuffer(parser=self.parser, callback=partial(self.plane.set_bios, field_name), **buff_params)
+            buffer = getattr(import_module('dcspy.dcsbios'), proto_data['class'])
+            buffer(parser=self.parser, callback=partial(self.plane.set_bios, field_name), **proto_data['args'])
 
     def check_buttons(self) -> int:
         """

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,3 @@
 packaging
 Pillow
 requests
-typing_extensions; python_version < '3.8'

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,4 @@
 packaging
 Pillow
 requests
+typing_extensions; python_version < '3.8'

--- a/tests/test_aircraft.py
+++ b/tests/test_aircraft.py
@@ -48,7 +48,7 @@ def test_button_pressed_for_hornet(button, result, hornet):
                                               ('FuelTotal', '104T', '104T')])
 def test_set_bios_for_hornet(selector, value, result, hornet):
     hornet.set_bios(selector, value, False)
-    assert hornet.bios_data[selector]['val'] == result
+    assert hornet.bios_data[selector]['value'] == result
 
 
 @mark.parametrize('model', ['FA18Chornet', 'F16C50', 'Ka50'])

--- a/tests/test_dcsbios.py
+++ b/tests/test_dcsbios.py
@@ -109,3 +109,19 @@ def test_simple_instance_of_buffers(class_name, params, protocol_parser):
 
     buff = getattr(dcsbios, class_name)(parser=protocol_parser, callback=lambda x: x, **params)
     assert 'on_dcsbios_write' in dir(buff)
+
+
+def test_integer_buffer_callback(protocol_parser):
+    from functools import partial
+    from dcspy.dcsbios import IntegerBuffer
+
+    def _callback(*args, **kwargs):
+        assert args == (1,)
+        assert kwargs == dict()
+
+    IntegerBuffer(parser=protocol_parser, address=0x1938, mask=0x200, shift_by=0x9, callback=partial(_callback))
+    protocol_parser.state = 'DATA_HIGH'
+    protocol_parser.count = 1
+    protocol_parser.address = 0x1938
+    protocol_parser.data = 0x927  # 0x827
+    protocol_parser.process_byte(bytes([0x1]))

--- a/tests/test_dcsbios.py
+++ b/tests/test_dcsbios.py
@@ -1,3 +1,6 @@
+from pytest import mark
+
+
 def test_process_byte_wait_for_sync_to_address_low(protocol_parser):
     assert protocol_parser.state == 'WAIT_FOR_SYNC'
     for _ in range(4):
@@ -97,3 +100,12 @@ def test_process_byte_wait_for_sync_callback(protocol_parser):
     protocol_parser.frame_sync_callbacks.add(partial(_callback))
     protocol_parser.sync_byte_count = 3
     protocol_parser.process_byte(bytes([0x55]))
+
+
+@mark.parametrize('class_name, params', [('StringBuffer', {'address': 0x192a, 'length': 6}),
+                                         ('IntegerBuffer', {'address': 0x1936, 'mask': 0x8000, 'shift_by': 0xf})])
+def test_simple_instance_of_buffers(class_name, params, protocol_parser):
+    from dcspy import dcsbios
+
+    buff = getattr(dcsbios, class_name)(parser=protocol_parser, callback=lambda x: x, **params)
+    assert 'on_dcsbios_write' in dir(buff)


### PR DESCRIPTION
## Description
- allow usage of `IntegerBuffer()` to collect additional data form DCS-BIOS  
- load dynamically `IntegerBuffer()` class with constructor parameters
- or recognize by **type** key in `bios_data` member of `Aircraft` instance and crate instance of correct buffer (String or Integer)

## Todo
- [x] changes in `aircrafts` module
- [x] correct handling in G13 handler
- [x] add tests of `IntegerBuffer`
- [x] update collaboration documentation
