### PR TITLE
Use text during start of DCSpy

### DIFF
--- a/dcspy/lcd_sdk.py
+++ b/dcspy/lcd_sdk.py
@@ -213,6 +213,26 @@ def logi_lcd_color_set_text(line_no: int, text: str, rgb: Tuple[int, int, int] =
     return False
 
 
+def update_text(txt: List[str]) -> None:
+    """
+    Update display LCD with list of text.
+    
+    For mono LCD it takes 4 elements of list and display as 4 rows.
+    For color LCD  takes 8 elements of list and display as 8 rows.
+    :param txt: List of strings to display, row by row
+    """
+    if logi_lcd_is_connected(TYPE_MONO):
+        for line_no, line in enumerate(txt):
+            logi_lcd_mono_set_text(line_no, line)
+        logi_lcd_update()
+    elif logi_lcd_is_connected(TYPE_COLOR):
+        for line_no, line in enumerate(txt):
+            logi_lcd_color_set_text(line_no, line)
+        logi_lcd_update()
+    else:
+        LOG.warning('LCD is not connected')
+
+
 def update_display(image: Image) -> None:
     """
     Update display LCD with image.

--- a/dcspy/starter.py
+++ b/dcspy/starter.py
@@ -49,10 +49,9 @@ def _sock_err_handler(lcd: LogitechKeyboard, start_time: float, current_ver: str
     """
     wait_time = gmtime(time() - start_time)
     spacer = ' ' * 13
-    # todo: use settext form sdk
-    lcd.display = ['Logitech LCD OK', 'No new data from DCS:',
-                   f'{spacer}{wait_time.tm_min:02d}:{wait_time.tm_sec:02d} [min:s]',
-                   f'dcspy: v{__version__} ({current_ver})']
+    lcd.text = ['Logitech LCD OK', 'No new data from DCS:',
+                f'{spacer}{wait_time.tm_min:02d}:{wait_time.tm_sec:02d} [min:s]',
+                f'dcspy: v{__version__} ({current_ver})']
 
 
 def _prepare_socket() -> socket.socket:

--- a/tests/test_logitech.py
+++ b/tests/test_logitech.py
@@ -13,7 +13,7 @@ def test_keyboard_base_basic_check(keyboard_base):
     assert str(keyboard_base) == 'LogitechKeyboard: 160x43'
     logitech_repr = repr(keyboard_base)
     data = ('parser', 'ProtocolParser', 'plane_name', 'plane_detected', 'already_pressed', 'buttons',
-            '_display', 'plane', 'Aircraft')
+            '_text', 'plane', 'Aircraft')
     for test_string in data:
         assert test_string in logitech_repr
 
@@ -46,11 +46,11 @@ def test_keyboard_color_button_handle(keyboard_color, sock):
 def test_keyboard_mono_detecting_plane(plane_str, plane, display, detect, keyboard_mono):
     from dcspy import lcd_sdk
     with patch.object(lcd_sdk, 'logi_lcd_is_connected', return_value=True):
-        with patch.object(lcd_sdk, 'logi_lcd_mono_set_background', return_value=True):
+        with patch.object(lcd_sdk, 'logi_lcd_mono_set_text', return_value=True):
             with patch.object(lcd_sdk, 'logi_lcd_update', return_value=True):
                 keyboard_mono.detecting_plane(plane_str)
     assert keyboard_mono.plane_name == plane
-    assert keyboard_mono._display == ['Detected aircraft:'] + [plane] + display
+    assert keyboard_mono._text == ['Detected aircraft:'] + [plane] + display
     assert keyboard_mono.plane_detected is detect
 
 
@@ -66,10 +66,12 @@ def test_check_keyboard_display_and_prepare_image(mode, size, lcd_type, keyboard
     assert isinstance(keyboard.plane, Aircraft)
     assert isinstance(keyboard.lcd, LcdInfo)
     assert keyboard.lcd.type == lcd_type
-    assert isinstance(keyboard.display, list)
-    with patch.object(lcd_sdk, 'update_display', return_value=True):
-        keyboard.display = ['1', '2']
-        assert len(keyboard.display) == 2
+    assert isinstance(keyboard.text, list)
+    with patch.object(lcd_sdk, 'update_text', return_value=True):
+        keyboard.text = ['1', '2']
+        assert len(keyboard.text) == 2
+
+    # this should be move in separate test
     img = keyboard._prepare_image()
     assert img.mode == mode
     assert img.size == size


### PR DESCRIPTION
## Description
Allow update LCD with text instead of image. Check if using image in logitech is still needed.

## Related PR and issues
* #22

