### PR TITLE
Load empty yaml when starting logitech module

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+## 3.1.3
+* Fix loading empty YAML file when Loading Logitech Keyboard instance 
+
 ## 3.1.2
 * Show messagebox during stat-up when Git executable is missing
 * Add dcs.log to debug data collection

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,5 @@
 ## 3.1.3
-* Fix loading empty YAML file when Loading Logitech Keyboard instance 
+* Fix loading empty YAML file when Loading Logitech Keyboard instance
 
 ## 3.1.2
 * Show messagebox during stat-up when Git executable is missing

--- a/dcspy/aircraft.py
+++ b/dcspy/aircraft.py
@@ -59,7 +59,8 @@ class BasicAircraft:
         self.bios_data: Dict[str, Union[str, int]] = {}
         self.cycle_buttons: Dict[Union[LcdButton, Gkey], CycleButton] = {}
         self.button_actions: Dict[Union[LcdButton, Gkey], str] = {}
-        self._load_plane_yaml()
+        if self.bios_name:
+            self._load_plane_yaml()
 
     def _load_plane_yaml(self) -> None:
         """Load plane's YAML file with configuration and apply."""


### PR DESCRIPTION
## Description
Fix:
```
Traceback (most recent call last):
  File "D:\Projects\dcspy_dev\dcspy\utils.py", line 66, in load_yaml
    with open(file=full_path, encoding='utf-8') as yaml_file:
         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
FileNotFoundError: [Errno 2] No such file or directory: 'C:\\Users\\mplic\\AppData\\Local\\dcspy\\.yaml'
```

## Related PR and issues
* #242 
