### PR TITLE
Fix old migration from 3.0.0 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ Internal:
 * Add dcs.log to debug data collection
 * Internal:
   * Update GitPython library
+  * Fix old migration from 3.0.0 release
 
 ## 3.1.1
 * Fix parsing data for **AH-64D Apache**

--- a/dcspy/migration.py
+++ b/dcspy/migration.py
@@ -54,6 +54,18 @@ def _filter_api_ver_func(cfg_ver: str) -> Iterator[Callable[[DcspyConfigYaml], N
             yield globals()['_api_ver_{}'.format(api_ver.replace('.', '_'))]
 
 
+def _api_ver_3_1_3(cfg: DcspyConfigYaml) -> None:
+    """
+    Migrate to version 3.1.3.
+
+    :param cfg: Configuration dictionary
+    """
+    user_appdata = get_config_yaml_location()
+    makedirs(name=user_appdata, exist_ok=True)
+    _remove_key(cfg, 'font_mono_xs')
+    _remove_key(cfg, 'font_color_xs')
+
+
 def _api_ver_3_1_1(cfg: DcspyConfigYaml) -> None:
     """
     Migrate to version 3.1.1.


### PR DESCRIPTION
## Description
Fix old migration from 3.0.0 release
```
'font_color_s'  -> 'font_color_m'
'font_color_xs' -> 'font_color_s'
'font_mono_s' -> 'font_mono_m'
'font_mono_xs' -> 'font_mono_s'
```
## Related PR and issues
* #246 
