### PR TITLE
Add support for push button actions

### DIFF
--- a/dcspy/aircraft.py
+++ b/dcspy/aircraft.py
@@ -73,6 +73,10 @@ class BasicAircraft:
                     cycle_button = CycleButton.from_request(request)
                     cycle_buttons[key] = cycle_button
                     bios_data[cycle_button.ctrl_name] = int()
+                elif 'CUSTOM BUTTON' in request:
+                    request = request.split(' CUSTOM BUTTON')[0]
+                    request = f'{request} 1\n|{request} 0\n'
+                    button_actions[key] = request
                 elif 'CUSTOM' in request:
                     request = request.split('CUSTOM ')[1]
                     request = request.replace('|', '\n|')


### PR DESCRIPTION
## Description

This PR (currently hacky but just a PoC) provides an implementation of supporting push button actions. These are actions for example when pressing the COM1 button on the F-16 ICP.

The existing DSCpy supports `TOGGLE` action buttons as per the DCS-BIOS json configuration below.

```json
"ICP_COM1_BTN": {
  "api_variant": "momentary_last_position",
  "category": "UFC",
  "control_type": "selector",
  "description": "ICP COM Override Button, COM1(UHF)",
  "identifier": "ICP_COM1_BTN",
  "inputs": [
    {
      "description": "switch to previous or next state",
      "interface": "fixed_step"
    },
    {
      "description": "set position",
      "interface": "set_state",
      "max_value": 1
    },
    {
      "argument": "TOGGLE",
      "description": "Toggle switch state",
      "interface": "action"
    }
  ],
  "momentary_positions": "none",
  "outputs": [
    {
    "address": 17448,
    "address_mask_identifier": "F_16C_50_ICP_COM1_BTN_AM",
    "address_mask_shift_identifier": "F_16C_50_ICP_COM1_BTN",
    "description": "selector position",
    "mask": 16384,
    "max_value": 1,
    "shift_by": 14,
    "suffix": "",
    "type": "integer"
    }
  ],
  "physical_variant": "push_button"
}
```

In the DCSpy configuration file for these this appears like so:

`G1_M1: ICP_COM1_BTN TOGGLE`

The current implementation of this `TOGGLE` means that it is either on or off. This means that you need to press the ICP button twice, once to press it, and then again to "unpress" it, which simulates the key down / key up.

In the DCS-BIOS configuration we can see that the `physical_variant` of this is `push_button` so should just automatically do a key down and key up.

Because DCSpy does not have a "push button" type this PoC PR just reuses the existing Custom option in the UI and when provided with the text `BUTTON` does the following:
1. checks if there is a `CUSTOM BUTTON` entry in the config file
2. creates a button action of `<control> 1\n|<control> 0\n` that is used for the key handling request to chain the key down / key up events.

This means that instead of needing to put in custom text of `ICP_COM1_BTN 1|ICP_COM1_BTN 0|` you can just specify `BUTTON` and it will automatically create that.

<img width="979" alt="Screen Shot 2024-02-05 at 4 19 39 PM" src="https://github.com/emcek/dcspy/assets/4580060/0289cc7a-e6b6-458b-8ca8-b45538b624a9">


**NOTE:** I attempted to create an actual "push_button" type and associated radio button for the UI, e.g. `rb_push_button`, but this didn't work (...my python experience, especially with Python and Qt, is weak). Adding it to the `qtdcs.ui` xml file and the code in `qt_gui.py` to find the QRadioButton child with that `rb_push_button` label like the other buttons didn't seem to find it and construct a radio button. I'd like to create a proper button, config handling for that (e.g. adds `BUTTON` to the config file like `TOGGLE` is instead of `CUSTOM BUTTON`), and have it default to this if the `primary_variant` is `push_button`.

## Todo

I haven't added any unit tests for this. For testing I built the CLI release and ran this on my machine and connected DCS to it to verify all the configuration worked and the buttons were pushed. I added a bunch of logging, not included here, to verify that the configuration file was loaded as expected, and when pushing buttons that the requests were being sent in the right format. Also tested with existing toggles and other custom configuration to make sure I hadn't broken the existing usage of the CUSTOM item which takes pipes for the custom text.

- [ ] Tests
- [ ] Documentation

