### PR TITLE
Ignore key up events if they are not for push button actions

### DIFF
--- a/dcspy/logitech.py
+++ b/dcspy/logitech.py
@@ -49,6 +49,7 @@ class KeyboardManager:
         self.plane_name = ''
         self.bios_name = ''
         self.plane_detected = False
+        self.lcdbutton_pressed = False
         self._display: List[str] = []
         self.lcd = kwargs.get('lcd_type', LcdMono)
         self.model = KeyboardModel(name='', klass='', modes=0, gkeys=0, lcdkeys=(LcdButton.NONE,), lcd='mono')
@@ -163,7 +164,11 @@ class KeyboardManager:
         """
         for btn in self.buttons:
             if lcd_sdk.logi_lcd_is_button_pressed(btn.value):
-                return LcdButton(btn)
+                if not self.lcdbutton_pressed:
+                    self.lcdbutton_pressed = True
+                    return LcdButton(btn)
+                return LcdButton.NONE
+        self.lcdbutton_pressed = False
         return LcdButton.NONE
 
     def button_handle(self) -> None:

--- a/dcspy/logitech.py
+++ b/dcspy/logitech.py
@@ -12,7 +12,7 @@ from PIL import Image, ImageDraw
 from dcspy import get_config_yaml_item
 from dcspy.aircraft import BasicAircraft, MetaAircraft
 from dcspy.dcsbios import ProtocolParser
-from dcspy.models import (SEND_ADDR, SUPPORTED_CRAFTS, TIME_BETWEEN_REQUESTS, Gkey, KeyboardModel, LcdButton, LcdColor, LcdMono, ModelG13, ModelG15v1,
+from dcspy.models import (KEY_DOWN, SEND_ADDR, SUPPORTED_CRAFTS, TIME_BETWEEN_REQUESTS, Gkey, KeyboardModel, LcdButton, LcdColor, LcdMono, ModelG13, ModelG15v1,
                           ModelG15v2, ModelG19, ModelG510)
 from dcspy.sdk import lcd_sdk
 from dcspy.sdk.key_sdk import GkeySdkManager
@@ -49,7 +49,6 @@ class KeyboardManager:
         self.plane_name = ''
         self.bios_name = ''
         self.plane_detected = False
-        self.lcdbutton_pressed = False
         self._display: List[str] = []
         self.lcd = kwargs.get('lcd_type', LcdMono)
         self.model = KeyboardModel(name='', klass='', modes=0, gkeys=0, lcdkeys=(LcdButton.NONE,), lcd='mono')
@@ -164,11 +163,7 @@ class KeyboardManager:
         """
         for btn in self.buttons:
             if lcd_sdk.logi_lcd_is_button_pressed(btn.value):
-                if not self.lcdbutton_pressed:
-                    self.lcdbutton_pressed = True
-                    return LcdButton(btn)
-                return LcdButton.NONE
-        self.lcdbutton_pressed = False
+                return LcdButton(btn)
         return LcdButton.NONE
 
     def button_handle(self) -> None:
@@ -180,7 +175,7 @@ class KeyboardManager:
         """
         button = self.check_buttons()
         if button.value:
-            self._send_request(button)
+            self._send_request(button, key_down=KEY_DOWN)
 
     def _send_request(self, button: Union[LcdButton, Gkey], key_down: Optional[int] = None) -> None:
         """

--- a/tests/test_aircraft.py
+++ b/tests/test_aircraft.py
@@ -4,7 +4,7 @@ from unittest.mock import patch
 
 from pytest import mark, raises
 
-from dcspy.models import LcdButton
+from dcspy.models import KEY_DOWN, LcdButton
 from tests.helpers import all_plane_list, compare_images, set_bios_during_test
 
 
@@ -176,7 +176,7 @@ def test_meta_plane(keyboard, plane_name, request):
 def test_button_pressed_for_planes(plane, button, result, request):
     plane = request.getfixturevalue(plane)
     key_req = plane.button_request(button)
-    assert list(key_req.bytes_requests(key_down=None)) == result
+    assert list(key_req.bytes_requests(key_down=KEY_DOWN)) == result
 
 
 @mark.parametrize('button, result', [
@@ -193,7 +193,7 @@ def test_button_pressed_for_apache_color(button, result, ah64dblkii_color):
     from dcspy.aircraft import ApacheEufdMode
     ah64dblkii_color.mode = ApacheEufdMode.WCA
     key_req = ah64dblkii_color.button_request(button)
-    assert list(key_req.bytes_requests(key_down=None)) == result
+    assert list(key_req.bytes_requests(key_down=KEY_DOWN)) == result
 
 
 @mark.parametrize('plane, ctrl_name, btn, values', [
@@ -226,7 +226,7 @@ def test_get_next_value_for_cycle_buttons(plane, ctrl_name, btn, values, request
     expected_out = []
     for val in values:
         key_req = plane.button_request(btn)
-        generated_out.extend(key_req.bytes_requests(key_down=None))
+        generated_out.extend(key_req.bytes_requests(key_down=KEY_DOWN))
         expected_out.extend([f'{ctrl_name} {val}\n'.encode('ascii')])
     assert generated_out == expected_out
 

--- a/tests/test_logitech.py
+++ b/tests/test_logitech.py
@@ -11,7 +11,7 @@ def test_keyboard_base_basic_check(keyboard_base):
 
     assert str(keyboard_base) == 'KeyboardManager: 160x43'
     logitech_repr = repr(keyboard_base)
-    data = ('parser', 'ProtocolParser', 'plane_name', 'plane_detected', 'lcdbutton_pressed', 'buttons',
+    data = ('parser', 'ProtocolParser', 'plane_name', 'plane_detected', 'buttons',
             '_display', 'plane', 'BasicAircraft', 'vert_space', 'lcd', 'LcdInfo', 'gkey', 'buttons', 'model', 'KeyboardModel')
     for test_string in data:
         assert test_string in logitech_repr

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -336,7 +336,7 @@ def test_zigzag_iterator_direction():
     ('COM1 CYCLE 1 3', 'G1_M1', KEY_DOWN, [True, False, False, [b'COM1 3\n']]),
     ('COM1 CYCLE 1 3', 'G1_M1', KEY_UP, [True, False, False, []]),
     ('COM1 CYCLE 1 3', 'ONE', KEY_DOWN, [True, False, False, [b'COM1 3\n']]),
-    ('COM2 CUSTOM COM2 1|COM2 0|', 'G2_M2', 1, [False, True, False, [b'COM2 1\n', b'COM2 0\n']]),
+    ('COM2 CUSTOM COM2 1|COM2 0|', 'G2_M2', KEY_DOWN, [False, True, False, [b'COM2 1\n', b'COM2 0\n']]),
     ('COM2 CUSTOM COM2 1|COM2 0|', 'G2_M2', KEY_UP, [False, True, False, []]),
     ('COM2 CUSTOM COM2 1|COM2 0|', 'TWO', KEY_DOWN, [False, True, False, [b'COM2 1\n', b'COM2 0\n']]),
     ('RADIO_1 PUSH_BUTTON', 'G3_M3', KEY_DOWN, [False, False, True, [b'RADIO_1 1\n']]),

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -1,5 +1,7 @@
 from pytest import mark, raises
 
+from dcspy.models import KEY_DOWN, KEY_UP
+
 
 # <=><=><=><=><=> Control / ControlKeyData <=><=><=><=><=>
 @mark.parametrize('get_ctrl_for_plane, results', [
@@ -331,18 +333,18 @@ def test_zigzag_iterator_direction():
 
 # <=><=><=><=><=> RequestModel <=><=><=><=><=>
 @mark.parametrize('str_req, key, key_down, result', [
-    ('COM1 CYCLE 1 3', 'G1_M1', 1, [True, False, False, [b'COM1 3\n']]),
-    ('COM1 CYCLE 1 3', 'G1_M1', 0, [True, False, False, [b'COM1 3\n']]),
-    ('COM1 CYCLE 1 3', 'ONE', None, [True, False, False, [b'COM1 3\n']]),
+    ('COM1 CYCLE 1 3', 'G1_M1', KEY_DOWN, [True, False, False, [b'COM1 3\n']]),
+    ('COM1 CYCLE 1 3', 'G1_M1', KEY_UP, [True, False, False, []]),
+    ('COM1 CYCLE 1 3', 'ONE', KEY_DOWN, [True, False, False, [b'COM1 3\n']]),
     ('COM2 CUSTOM COM2 1|COM2 0|', 'G2_M2', 1, [False, True, False, [b'COM2 1\n', b'COM2 0\n']]),
-    ('COM2 CUSTOM COM2 1|COM2 0|', 'G2_M2', 0, [False, True, False, [b'COM2 1\n', b'COM2 0\n']]),
-    ('COM2 CUSTOM COM2 1|COM2 0|', 'TWO', None, [False, True, False, [b'COM2 1\n', b'COM2 0\n']]),
-    ('RADIO_1 PUSH_BUTTON', 'G3_M3', 1, [False, False, True, [b'RADIO_1 1\n']]),
-    ('RADIO_1 PUSH_BUTTON', 'G3_M3', 0, [False, False, True, [b'RADIO_1 0\n']]),
-    ('RADIO_1 PUSH_BUTTON', 'LEFT', None, [False, False, True, [b'RADIO_1 1\n', b'RADIO_1 0\n']]),
-    ('MASTER_ARM 2', 'G1_M2', 1, [False, False, False, [b'MASTER_ARM 2\n']]),
-    ('MASTER_ARM 2', 'G1_M2', 0, [False, False, False, [b'MASTER_ARM 2\n']]),
-    ('MASTER_ARM 2', 'RIGHT', None, [False, False, False, [b'MASTER_ARM 2\n']]),
+    ('COM2 CUSTOM COM2 1|COM2 0|', 'G2_M2', KEY_UP, [False, True, False, []]),
+    ('COM2 CUSTOM COM2 1|COM2 0|', 'TWO', KEY_DOWN, [False, True, False, [b'COM2 1\n', b'COM2 0\n']]),
+    ('RADIO_1 PUSH_BUTTON', 'G3_M3', KEY_DOWN, [False, False, True, [b'RADIO_1 1\n']]),
+    ('RADIO_1 PUSH_BUTTON', 'G3_M3', KEY_UP, [False, False, True, [b'RADIO_1 0\n']]),
+    ('RADIO_1 PUSH_BUTTON', 'LEFT', KEY_DOWN, [False, False, True, [b'RADIO_1 1\n', b'RADIO_1 0\n']]),
+    ('MASTER_ARM 2', 'G1_M2', KEY_DOWN, [False, False, False, [b'MASTER_ARM 2\n']]),
+    ('MASTER_ARM 2', 'G1_M2', KEY_UP, [False, False, False, []]),
+    ('MASTER_ARM 2', 'RIGHT', KEY_DOWN, [False, False, False, [b'MASTER_ARM 2\n']]),
 ], ids=[
     'GKey CYCLE down',
     'GKey CYCLE up',
@@ -371,13 +373,13 @@ def test_request_model_properties(str_req, key, key_down, result):
     assert str(req) == f'{req.ctrl_name}: {str_req}'
 
 
-@mark.parametrize('key, key_down', [
-    ('ONE', None),
-    ('G1_M1', 1),
-    ('G1_M1', 0),
+@mark.parametrize('key, key_down, result', [
+    ('ONE', KEY_DOWN, [b'\n']),
+    ('G1_M1', KEY_DOWN, [b'\n']),
+    ('G1_M1', KEY_UP, []),
 ])
-def test_empty_request_model_(key, key_down):
+def test_empty_request_model_(key, key_down, result):
     from dcspy.models import RequestModel, get_key_instance
 
     empty_req = RequestModel.empty(key=get_key_instance(key))
-    assert empty_req.bytes_requests(key_down=key_down) == [b'\n']
+    assert empty_req.bytes_requests(key_down=key_down) == result


### PR DESCRIPTION
## Description

The G-Key SDK and handler send a 1 for key down and 0 for key up. For "push button" actions the key up and key down work as expected when the request bytes are retrieved from the button. When using a button with something like `CUSTOM` or `CYCLE` however this is sending the custom request bytes twice, once when the key is pressed down, and then again when the key is released.

The changes in this PR are to ignore the key up events for keys that aren't push buttons are only sent once, i.e. when the button is pressed.

**NOTE:** The `test_logitech.test_keyboard_check_buttons` unit test is currently failing due to these changes. I don't know enough about this tests intent and the usage of `call` etc. to know what should be changed for this one.

