### PR TITLE
Support for Python 3.13

### DIFF
--- a/.github/actions/setup-python/action.yaml
+++ b/.github/actions/setup-python/action.yaml
@@ -13,4 +13,5 @@ runs:
       shell: bash
       run: |
         python -m pip install -U pip setuptools wheel twine build
+        python -m pip install pyside6 --ignore-requires-python
         python -m pip install -U -r requirements_test.txt

--- a/.github/actions/setup-python/action.yaml
+++ b/.github/actions/setup-python/action.yaml
@@ -3,10 +3,10 @@ description: Sets up the dcspy Python environment.
 runs:
   using: composite
   steps:
-    - name: "Set up Python 3.12"
+    - name: "Set up Python 3.13"
       uses: actions/setup-python@v5
       with:
-        python-version: "3.12"
+        python-version: "3.13"
         cache: pip
 
     - name: "Install requirements"

--- a/.github/actions/setup-python/action.yaml
+++ b/.github/actions/setup-python/action.yaml
@@ -13,5 +13,4 @@ runs:
       shell: bash
       run: |
         python -m pip install -U pip setuptools wheel twine build
-        python -m pip install pyside6 --ignore-requires-python
         python -m pip install -U -r requirements_test.txt

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -10,7 +10,7 @@ on:
 
 jobs:
   coverage:
-    name: windows-latest py3.12
+    name: windows-latest py3.13
     runs-on: windows-latest
     steps:
       - name: "Checkout"
@@ -31,7 +31,7 @@ jobs:
         uses: actions/upload-artifact@v4
         if: always()
         with:
-          name: coverage_3_12
+          name: coverage_3_13
           path: |
             covhtml/*
             coverage.xml

--- a/.github/workflows/nuitka.yml
+++ b/.github/workflows/nuitka.yml
@@ -33,7 +33,7 @@ jobs:
       - uses: Nuitka/Nuitka-Action@main
         if: ${{ endsWith( matrix.nuitka_type, '_nuitka') }}
         with:
-          nuitka-version: 2.4.8
+          nuitka-version: 2.4.11
           script-name: src/dcs_py.py
           onefile: true
           windows-console-mode: disable
@@ -54,7 +54,7 @@ jobs:
       - uses: Nuitka/Nuitka-Action@main
         if: ${{ endsWith( matrix.nuitka_type, '_cli') }}
         with:
-          nuitka-version: 2.4.8
+          nuitka-version: 2.4.11
           script-name: src/dcs_py.py
           onefile: true
           windows-console-mode: force

--- a/.github/workflows/nuitka.yml
+++ b/.github/workflows/nuitka.yml
@@ -12,8 +12,17 @@ jobs:
       - name: "Checkout"
         uses: actions/checkout@v4
 
-      - name: "Set up Python environment"
-        uses: ./.github/actions/setup-python
+      - name: "Set up Python 3.12"
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+          cache: pip
+
+      - name: "Install requirements"
+        shell: bash
+        run: |
+          python -m pip install -U pip
+          python -m pip install -U -r requirements.txt
 
       - name: "Generate version info file"
         shell: pwsh

--- a/.github/workflows/sonarcloud.yml
+++ b/.github/workflows/sonarcloud.yml
@@ -18,10 +18,10 @@ jobs:
         with:
           fetch-depth: 0  # Shallow clones should be disabled for a better relevancy of analysis
 
-      - name: "Set up Python 3.12"
+      - name: "Set up Python 3.13"
         uses: actions/setup-python@v5
         with:
-          python-version: 3.12
+          python-version: 3.13
           cache: pip
 
       - name: "Install MS Fonts"

--- a/.github/workflows/style.yml
+++ b/.github/workflows/style.yml
@@ -72,7 +72,7 @@ jobs:
         uses: actions/upload-artifact@v4
         if: always()
         with:
-          name: mypy_3_12
+          name: mypy_3_13
           path: |
             mypyhtml/*
           retention-days: 4

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -10,6 +10,9 @@ jobs:
       matrix:
         os: [ubuntu-latest, windows-latest]
         python-version: ['3.9', '3.10', '3.11', '3.12', '3.13.0-rc.2']
+        exclude:
+          - os: ubuntu-latest
+            python-version: '3.13.0-rc.2'
     steps:
       - name: "Checkout"
         uses: actions/checkout@v4

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -9,7 +9,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest, windows-latest]
-        python-version: ['3.9', '3.10', '3.11', '3.12', '3.13.0-rc.2']
+        python-version: ['3.9', '3.10', '3.11', '3.12', '3.13']
     steps:
       - name: "Checkout"
         uses: actions/checkout@v4

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -10,9 +10,6 @@ jobs:
       matrix:
         os: [ubuntu-latest, windows-latest]
         python-version: ['3.9', '3.10', '3.11', '3.12', '3.13.0-rc.2']
-        exclude:
-          - os: ubuntu-latest
-            python-version: '3.13.0-rc.2'
     steps:
       - name: "Checkout"
         uses: actions/checkout@v4

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -9,7 +9,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest, windows-latest]
-        python-version: ['3.9', '3.10', '3.11', '3.12']
+        python-version: ['3.9', '3.10', '3.11', '3.12', '3.13.0-rc.2']
     steps:
       - name: "Checkout"
         uses: actions/checkout@v4

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -30,6 +30,7 @@ jobs:
 
       - name: "Install dependencies"
         run: |
+          pip install -vv pyside6
           python -m pip install --upgrade pip setuptools
           pip install -Ur requirements_test.txt
 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -30,7 +30,6 @@ jobs:
 
       - name: "Install dependencies"
         run: |
-          pip install -vv pyside6
           python -m pip install --upgrade pip setuptools
           pip install -Ur requirements_test.txt
 

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -4,7 +4,7 @@ ci:
   skip: [pip-audit]
 
 default_language_version:
-  python: python3.12
+  python: python3.13
 
 repos:
   - repo: https://github.com/pre-commit/pre-commit-hooks

--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -5,7 +5,7 @@ formats: all
 build:
   os: ubuntu-22.04
   tools:
-    python: "3.13"
+    python: "3.12"
 
 mkdocs:
   configuration: mkdocs.yml

--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -5,7 +5,7 @@ formats: all
 build:
   os: ubuntu-22.04
   tools:
-    python: "3.12"
+    python: "3.13"
 
 mkdocs:
   configuration: mkdocs.yml

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 3.5.3
+* Internal:
+  * add early support for Python 3.13
+
 ## 3.5.2
 * GUI should not be hide when starting when configuration is wrong (@emcek)
 * Generate BIOS JSON's file during start-up and after BIOS update (@emcek)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 * Use symbolic link to DCS-BIOS live repository #347 (@emcek)
 * Compile DCS-BIOS using LuaJIT from lupa library !373 (@emcek)
 * internal:
-  * Update PySide6 framework to 6.7.3
+  * Update PySide6 framework to 6.8.0.2
   * add early support for Python 3.13
 
 ## 3.5.2

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,7 @@
 * Compile DCS-BIOS using LuaJIT from lupa library !373 (@emcek)
 * internal:
   * Update PySide6 framework to 6.8.0.2
-  * add early support for Python 3.13
+  * add support for Python 3.13
 
 ## 3.5.2
 * GUI should not be hide when starting when configuration is wrong (@emcek)

--- a/README.md
+++ b/README.md
@@ -58,8 +58,7 @@ Why a such way? Basically advanced support is for aircraft that I own and theref
   * [Git](https://git-scm.com/download/win) it is necessary for using the live version of DCS-BIOS
 * DCS World: [2.9.7.59263](https://www.digitalcombatsimulator.com/en/news/changelog/stable/2.9.7.59263/), but any version from 2.9.* branch should be fine.
 * optional:
-  * [Python 3.12](https://www.python.org/downloads/) but 3.9+ should be fine (see [installation](https://dcspy.readthedocs.io/en/latest/install/))
-  * However, DCSpy 2.3.3 and earlier do not support Python 3.12
+  * [Python 3.13](https://www.python.org/downloads/) but 3.9+ should be fine (see [installation](https://dcspy.readthedocs.io/en/latest/install/))
 
 ## New ideas
 I have lots of plans and new ideas how to improve it internally and form a user's perspective, but don't hesitate to contact me. Maybe it will motivate me to implement some new stuff. Please open issue if you find a bug or have any crazy idea.

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@
 [![dcspy](https://snyk.io/advisor/python/dcspy/badge.svg)](https://snyk.io/advisor/python/dcspy)
 [![Patreon](https://img.shields.io/badge/Patreon-donate-ff424d?logo=patreon)](https://www.patreon.com/mplichta)
 [![Discord](https://img.shields.io/discord/672486999516774442?label=Discord&logo=discord&logoColor=lightblue)](https://discord.gg/SP5Yjx3)
-[![image](https://img.shields.io/badge/python-3.9%20%7C%203.10%20%7C%203.11%20%7C%203.12-blue.svg)](https://github.com/emcek/dcspy)
+[![image](https://img.shields.io/badge/python-3.9%20%7C%203.10%20%7C%203.11%20%7C%203.12%20%7C%203.13-blue.svg)](https://github.com/emcek/dcspy)
 [![pre-commit.ci status](https://results.pre-commit.ci/badge/github/emcek/dcspy/master.svg)](https://results.pre-commit.ci/latest/github/emcek/dcspy/master)
 [![Maintainability Rating](https://sonarcloud.io/api/project_badges/measure?project=emcek_dcspy&metric=sqale_rating)](https://sonarcloud.io/dashboard?id=emcek_dcspy)
 [![Downloads](https://static.pepy.tech/badge/dcspy)](https://pepy.tech/project/dcspy)

--- a/docs/install.md
+++ b/docs/install.md
@@ -21,7 +21,7 @@ Due to how Python application can be pack into executable file (using PyInstalle
 * Disadvantage: Python interpreter is needed, more steps, more complicated process
 
 1. Install [Logitech Gaming Software 9.04.49](https://support.logitech.com/software/lgs)
-2. Download [Python 3.12](https://www.python.org/downloads/) but 3.9+ should be fine, please choose **Windows x86-64** version, file should be `python-3.12.0-amd64.exe`.
+2. Download [Python 3.13](https://www.python.org/downloads/) but 3.9+ should be fine, please choose **Windows x86-64** version, file should be `python-3.13.0-amd64.exe`.
 3. During Python installation please select
    * Optional Features:
      * pip
@@ -29,7 +29,7 @@ Due to how Python application can be pack into executable file (using PyInstalle
    * Advanced Options:
      * Associate files with Python (requires the py launcher)
      * Add Python to environment variables
-     * Customize install location: **C:\Python312** or **C:\Python**
+     * Customize install location: **C:\Python313** or **C:\Python**
 4. DCS-BIOS
    * You can skip for now and install DCS-BIOS directly from DCSpy (button Check DCS-BIOS, see [Configuration](usage.md#configuration)).
      It checks if new version exists, download, and unpack DCS-BIOS to `Save Games` folder and check `Export.lua` file.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -19,6 +19,7 @@ classifiers = [
     'Programming Language :: Python :: 3.10',
     'Programming Language :: Python :: 3.11',
     'Programming Language :: Python :: 3.12',
+    'Programming Language :: Python :: 3.13',
     'Operating System :: Microsoft :: Windows',
     'Operating System :: Microsoft :: Windows :: Windows 10',
     'Topic :: Games/Entertainment',

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -45,7 +45,7 @@ dependencies = [
     'pillow==11.0.0',
     'psutil==6.1.0',
     'pydantic==2.9.2',
-    'pyside6==6.8.0.1',
+    'pyside6==6.8.0.2',
     'pyyaml==6.0.2',
     'requests==2.32.3',
     'typing-extensions==4.12.2 ; python_full_version < "3.12"',

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,7 +5,7 @@ packaging==24.1
 pillow==11.0.0
 psutil==6.1.0
 pydantic==2.9.2
-PySide6==6.8.0.1
+PySide6==6.8.0.2
 PyYAML==6.0.2
 requests==2.32.3
 typing_extensions==4.12.2; python_version < '3.12'

--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -21,4 +21,4 @@ sonar.cpp.file.suffixes=-
 sonar.objc.file.suffixes=-
 
 # Python version supported
-sonar.python.version=3.9, 3.10, 3.11, 3.12
+sonar.python.version=3.9, 3.10, 3.11, 3.12, 3.13

--- a/uv.lock
+++ b/uv.lock
@@ -521,7 +521,7 @@ requires-dist = [
     { name = "pycodestyle", marker = "extra == 'test'", specifier = "==2.12.1" },
     { name = "pydantic", specifier = "==2.9.2" },
     { name = "pydocstyle", extras = ["toml"], marker = "extra == 'test'", specifier = "==6.3.0" },
-    { name = "pyside6", specifier = "==6.8.0.1" },
+    { name = "pyside6", specifier = "==6.8.0.2" },
     { name = "pytest", marker = "extra == 'test'", specifier = "==8.3.3" },
     { name = "pytest-cov", marker = "extra == 'test'", specifier = "==5.0.0" },
     { name = "pytest-qt", marker = "sys_platform == 'win32' and extra == 'test'", specifier = "==4.4.0" },
@@ -1874,7 +1874,7 @@ wheels = [
 
 [[package]]
 name = "pyside6"
-version = "6.8.0.1"
+version = "6.8.0.2"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "pyside6-addons" },
@@ -1882,39 +1882,39 @@ dependencies = [
     { name = "shiboken6" },
 ]
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/cb/2d/09a3215a48680fa76d1d74aea28e006f88fe3be992f4dea556f79e6e0c6e/PySide6-6.8.0.1-cp39-abi3-macosx_12_0_universal2.whl", hash = "sha256:a8f8ce89094e28a384821e5a4ba4ea952f3a02fe97a2b2ce5912eba4876554d0", size = 554058 },
-    { url = "https://files.pythonhosted.org/packages/6a/82/44ecc8615d6dd942198628f8da754cc71f306f84e05f4da1bdd7bb8d397e/PySide6-6.8.0.1-cp39-abi3-manylinux_2_28_x86_64.whl", hash = "sha256:1730d80f52cf9fb04c5267e652ddb1b7857fba5302860392fc73bfb9ab81ef8e", size = 554192 },
-    { url = "https://files.pythonhosted.org/packages/ae/1b/300346fb5791568943617a11b8a415477cb36c160b18c759d2fd737a4bf4/PySide6-6.8.0.1-cp39-abi3-manylinux_2_31_aarch64.whl", hash = "sha256:6567a4bc1a6bf77c13ea1fbe128ff68379afb31e92795cb501a7e085d8bf744e", size = 554304 },
-    { url = "https://files.pythonhosted.org/packages/bd/2f/5ba33be8855c5019c0c400a82079b4ee538a9935b7eb919a38e4b4ab5c13/PySide6-6.8.0.1-cp39-abi3-win_amd64.whl", hash = "sha256:9eb918758b9ca838febceb972db2c651ff652b7e5a893d8e59a38a744579ccc4", size = 560006 },
+    { url = "https://files.pythonhosted.org/packages/04/8c/2529634d9c6284db1fe7ea12688d5a43ce7abaaba5f5b45c23b2634b1fde/PySide6-6.8.0.2-cp39-abi3-macosx_12_0_universal2.whl", hash = "sha256:cecc6ce1da6cb04542ff5a0887734f63e6ecf54258d1786285b9c7904abd9b01", size = 554051 },
+    { url = "https://files.pythonhosted.org/packages/be/fb/508b0dd3f88e6bce7be4a9650801434319d563d9f04c439564f09cdb1238/PySide6-6.8.0.2-cp39-abi3-manylinux_2_28_x86_64.whl", hash = "sha256:3258f3c63dc5053b8d5b8d2588caca8bb3a36e2f74413511e4676df0e73b6f1e", size = 554194 },
+    { url = "https://files.pythonhosted.org/packages/99/1d/d96496aae8de2b14d372a1e46d06c7f355291c1f3cdd7f90ef48c7d88373/PySide6-6.8.0.2-cp39-abi3-manylinux_2_31_aarch64.whl", hash = "sha256:6a25cf784f978fa2a23b4d089970b27ebe14d26adcaf38b2819cb04483de4ce9", size = 554326 },
+    { url = "https://files.pythonhosted.org/packages/e2/94/33bad8ce9c6431325fa4b30e023fcc5ea04a77520f3c08ac184f74c3e218/PySide6-6.8.0.2-cp39-abi3-win_amd64.whl", hash = "sha256:3e8fffca9a934e30c07c3f34bb572f84bfcf02385acbc715e65fbdd9746ecc2b", size = 560103 },
 ]
 
 [[package]]
 name = "pyside6-addons"
-version = "6.8.0.1"
+version = "6.8.0.2"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "pyside6-essentials" },
     { name = "shiboken6" },
 ]
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/1b/d3/9010ff80f9f9f5f947706f4dc802a4a77ab2f2d1ac65948c8d18e9730299/PySide6_Addons-6.8.0.1-cp39-abi3-macosx_12_0_universal2.whl", hash = "sha256:db3622c257920e0d20de2f80ade6c064a48ee1e0c9a1cfe1f1d3bc2685c93996", size = 302011435 },
-    { url = "https://files.pythonhosted.org/packages/f7/41/a20a730417889b696aff35e338e2218fc03802ba27b77464c0afffd567e9/PySide6_Addons-6.8.0.1-cp39-abi3-manylinux_2_28_x86_64.whl", hash = "sha256:4cf9aebd26d908de4cbd5c7274f432370f8b0dc8dc7b748a6e6ade035fe28f28", size = 143714687 },
-    { url = "https://files.pythonhosted.org/packages/2f/4e/5ff008fcf01f689b44880d2504a9d769557de7481747523f0e984c47ab66/PySide6_Addons-6.8.0.1-cp39-abi3-manylinux_2_31_aarch64.whl", hash = "sha256:ed8f73e41b24ae6ea5ebb9dca1d4d6a6ddf06cffda63fa929d5e180ea9ac3cdd", size = 128861587 },
-    { url = "https://files.pythonhosted.org/packages/d8/30/8eb11c35d74042d7bca6b764dbf28cc95e1f50f6b72647a6efd122de61ac/PySide6_Addons-6.8.0.1-cp39-abi3-win_amd64.whl", hash = "sha256:066f0b6555f3351263a8d4936da5a95bd1b3e9bc83881f9f477d9146ccd3282f", size = 127835146 },
+    { url = "https://files.pythonhosted.org/packages/d1/a3/f44f6ad700a8534cbbb9f72a1cd203417890424ad59920bab76111fc524d/PySide6_Addons-6.8.0.2-cp39-abi3-macosx_12_0_universal2.whl", hash = "sha256:30c9ca570dd18ffbfd34ee95e0a319c34313a80425c4011d6ccc9f4cca0dc4c8", size = 302011435 },
+    { url = "https://files.pythonhosted.org/packages/0d/1f/50366475ec3129a25f1ffc25cbe0d2c7af71d285abf29b659ca5a2e6a87a/PySide6_Addons-6.8.0.2-cp39-abi3-manylinux_2_28_x86_64.whl", hash = "sha256:754a9822ab2dc313f9998edef69d8a12bc9fd61727543f8d30806ed272ae1e52", size = 143714688 },
+    { url = "https://files.pythonhosted.org/packages/cc/10/5f494352be48c8c419992c9974bd4f2168c9f99f58a7dad63dc2382396c1/PySide6_Addons-6.8.0.2-cp39-abi3-manylinux_2_31_aarch64.whl", hash = "sha256:553f3fa412f423929b5cd8b7d43fd5f02161851f10a438174a198b0f1a044df7", size = 128861616 },
+    { url = "https://files.pythonhosted.org/packages/e1/bb/c606032e9dbe5674c1d234ca3cc5679446f37cdbb555a82d6adc3941c0a7/PySide6_Addons-6.8.0.2-cp39-abi3-win_amd64.whl", hash = "sha256:ae4377a3e10fe720a9119677b31d8de13e2a5221c06b332df045af002f5f4c3d", size = 127835078 },
 ]
 
 [[package]]
 name = "pyside6-essentials"
-version = "6.8.0.1"
+version = "6.8.0.2"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "shiboken6" },
 ]
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/22/a7/0383a2c4771ca1008c2ee6b9fca76ad00e48053df6626fa17fe478522671/PySide6_Essentials-6.8.0.1-cp39-abi3-macosx_12_0_universal2.whl", hash = "sha256:2ae533a318b563ef7b73b1d7de3254e966423215589329207e45ee9adcb2e83c", size = 164669460 },
-    { url = "https://files.pythonhosted.org/packages/31/db/da4db014ed4b3b6d0ff148749d743d6e25692b9a66b9d5fbd10f4ecee6d6/PySide6_Essentials-6.8.0.1-cp39-abi3-manylinux_2_28_x86_64.whl", hash = "sha256:327a0f08cb1ee5af7f7ed81527bbdb3058e2a39a300efcc806e0289b50192f98", size = 95183947 },
-    { url = "https://files.pythonhosted.org/packages/7a/9d/ae433a47c1c8d63e1702c4055698e2f439c3e8961dcb0b60db595f424451/PySide6_Essentials-6.8.0.1-cp39-abi3-manylinux_2_31_aarch64.whl", hash = "sha256:6f573331261889992d450145c0f3a9a317e798b63c1318cc271422c0a74b2298", size = 92322388 },
-    { url = "https://files.pythonhosted.org/packages/e0/cd/1794fcc63c9f1b4d0349b2a7bb3ee925418054ec2ce92f95e69beb9d8382/PySide6_Essentials-6.8.0.1-cp39-abi3-win_amd64.whl", hash = "sha256:800d26aa51003b41c73e9c4cd4fd6c96fe91fc21f9862c3d459a7e2209f9475f", size = 72518525 },
+    { url = "https://files.pythonhosted.org/packages/1e/57/3210660aff9436429cb2709ed7bdf1808b075f8f6ed47853160e56903621/PySide6_Essentials-6.8.0.2-cp39-abi3-macosx_12_0_universal2.whl", hash = "sha256:3df4ed75bbb74d74ac338b330819b1a272e7f5cec206765c7176a197c8bc9c79", size = 164669671 },
+    { url = "https://files.pythonhosted.org/packages/34/72/6ef2f32e5ae5681cdd10cc7e627c453fcd389889fbc6a76d4e400a27af87/PySide6_Essentials-6.8.0.2-cp39-abi3-manylinux_2_28_x86_64.whl", hash = "sha256:7df6d6c1da4858dbdea77c74d7270d9c68e8d1bbe3362892abd1a5ade3815a50", size = 95184060 },
+    { url = "https://files.pythonhosted.org/packages/6f/ee/9023d3851054db24c28312744de8bdb80dcf8de20bd583b6520da416484f/PySide6_Essentials-6.8.0.2-cp39-abi3-manylinux_2_31_aarch64.whl", hash = "sha256:cf490145d18812a6cff48b0b0afb0bfaf7066744bfbd09eb071c3323f1d6d00d", size = 92322477 },
+    { url = "https://files.pythonhosted.org/packages/c7/24/57b5b10b4c641bf26e5fda3d71e2e14cbc796b334ef566b017d7b58c13cd/PySide6_Essentials-6.8.0.2-cp39-abi3-win_amd64.whl", hash = "sha256:d2f029b8c9f0106f57b26aa8c435435d7f509c80525075343e07177b283f862e", size = 72518805 },
 ]
 
 [[package]]
@@ -2209,13 +2209,13 @@ wheels = [
 
 [[package]]
 name = "shiboken6"
-version = "6.8.0.1"
+version = "6.8.0.2"
 source = { registry = "https://pypi.org/simple" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/e4/65/1c8a66e448ea1ee4745ba64b6a5604f9f40eeb807020baa181ae218a5d6d/shiboken6-6.8.0.1-cp39-abi3-macosx_12_0_universal2.whl", hash = "sha256:99cbb8d53bd2abcb61717a675bb3c1d7513868298b56cdfcae8aa27ed367577a", size = 392836 },
-    { url = "https://files.pythonhosted.org/packages/0f/7f/b81937dc3e414477e64f425a16a417a5d00cf8e2d954eee9264c5f4f14c0/shiboken6-6.8.0.1-cp39-abi3-manylinux_2_28_x86_64.whl", hash = "sha256:77b6e2eae8d48fe32a058e234778c42642eca1755de8b793e2d57857d7d037cf", size = 199992 },
-    { url = "https://files.pythonhosted.org/packages/5c/a1/1176683114bb7a1053ba2d3319c9f9f933ab4a132ef100c382fdb5f8ef42/shiboken6-6.8.0.1-cp39-abi3-manylinux_2_31_aarch64.whl", hash = "sha256:eb2db6f0cac42f10dc5b4bcf4ab5a8e079acb870877d0cb3d95cac80c20e4554", size = 189340 },
-    { url = "https://files.pythonhosted.org/packages/e0/ac/8c6e0a86ad84b8da61699d9e912850959fdee199cd3626c75759e35b57c4/shiboken6-6.8.0.1-cp39-abi3-win_amd64.whl", hash = "sha256:3f2601c0db8d1e860a2a1265936e616361b073360eb15153806638fbc3b7ff26", size = 1146289 },
+    { url = "https://files.pythonhosted.org/packages/d7/7b/3b0b541293a0296534da1a40b422b2323b67103367b1a1c704867d325ef8/shiboken6-6.8.0.2-cp39-abi3-macosx_12_0_universal2.whl", hash = "sha256:9019e1fcfeed8bb350222e981748ef05a2fec11e31ddf616657be702f0b7a468", size = 394561 },
+    { url = "https://files.pythonhosted.org/packages/42/73/6344e02a6734e17a86c5781df41293fa15245e4d7454992c1d82e77d49a9/shiboken6-6.8.0.2-cp39-abi3-manylinux_2_28_x86_64.whl", hash = "sha256:fa7d411c3c67b4296847b3f5f572268e219d947d029ff9d8bce72fe6982d92bc", size = 200711 },
+    { url = "https://files.pythonhosted.org/packages/13/cd/e9a6d0aa8794f777627a9fb3cffed0ac8449881b33e2325b5bcff10c36bc/shiboken6-6.8.0.2-cp39-abi3-manylinux_2_31_aarch64.whl", hash = "sha256:1aaa8b7f9138818322ef029b2c487d1c6e00dc3f53084e62e1d11bdea47e47c2", size = 189864 },
+    { url = "https://files.pythonhosted.org/packages/46/1f/4323ee8fdca5c441b349cd5569934d53a1fd9e3695d53089e18e20ef3611/shiboken6-6.8.0.2-cp39-abi3-win_amd64.whl", hash = "sha256:b11e750e696bb565d897e0f5836710edfb86bd355f87b09988bd31b2aad404d3", size = 1146649 },
 ]
 
 [[package]]


### PR DESCRIPTION
## Description
Early support for Python 3.13 (rc2):
* run unit test against 3.13

After official release of 3.13 it will be used as default for **Nuitka** and **PyInstaller**

Support for Python 3.13 require `PySide6>=6.8` ~~it also drop suport for Python 3.9~~
With release 6.8.0.2 supported Python version will be: `>=3.8`, `<3.14`

PySide6 python support:
![image](https://github.com/user-attachments/assets/99b0032c-603b-459f-b04e-bb1219a4419b)
