### PR TITLE
Update lupa to version 2.7

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 3.8.2
+* Internal:
+  * Update `lupa` to 2.7 (CVE-2026-34444) - #563 (@emcek)
+
 ## 3.8.1
 * Fix debugger tab in dark mode - #551 (@emcek)
 * Switching color schem, switching images and logos in Application - #554 (@emcek)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -41,7 +41,7 @@ dependencies = [
     'cffi==2.0.0',
     'eval-type-backport==0.3.1 ; python_version < "3.10"',
     'gitpython==3.1.46',
-    'lupa==2.6',
+    'lupa==2.7',
     'packaging==26.0',
     'pillow==12.2.0',
     'pydantic==2.12.5',


### PR DESCRIPTION
## Description
Update `lupa` to version 2.7

## Related PR and issues
* https://github.com/emcek/dcspy/security/dependabot/18
